### PR TITLE
Switch to using irods-icommands role from Ansible Galaxy

### DIFF
--- a/ansible/playbooks/instance_deploy/30_post_user_install.yml
+++ b/ansible/playbooks/instance_deploy/30_post_user_install.yml
@@ -4,6 +4,6 @@
   hosts: atmosphere
   roles:
     - atmo-fail2ban
-    - atmo-irods
+    - irods-icommands
     - atmo-realvncserver
     - atmo-cleanup

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,5 @@
+---
+
+# from Galaxy
+- src: CyVerse-Ansible.irods-icommands
+  name: irods-icommands

--- a/ansible/roles/irods-icommands/README.md
+++ b/ansible/roles/irods-icommands/README.md
@@ -1,0 +1,48 @@
+irods-icommands
+=========
+
+Installs the [iCommands](https://pods.iplantcollaborative.org/wiki/display/DS/Using+iCommands) 4.1.9<sup>[1](#centosfootnote)</sup> client for [iRODS](http://irods.org/), including irodsFs
+
+[![Build Status](https://travis-ci.org/CyVerse-Ansible/ansible-irods-icommands.svg?branch=master)](https://travis-ci.org/CyVerse-Ansible/ansible-irods-icommands)
+[![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-irods--icommands-blue.svg)](https://galaxy.ansible.com/CyVerse-Ansible/irods-icommands/)
+
+Tested working on CentOS 5+ and Ubuntu 12.04+. May also work for Debian and RHEL.
+
+For Ubuntu and CentOS 6+, installs using .deb/.rpm package from [http://irods.org/download/](http://irods.org/download/), mirrored by CyVerse on Amazon S3). Also cleans up links to old iCommands binaries which may have been previously installed outside of a package manager.
+
+<a name="centosfootnote">1</a>: For CentOS 5, no install package is available for iCommands 4.1.9, so we are still using the old iCommands 3.3.1. This role downloads binaries directly and adds them to PATH for all users.
+
+Requirements
+------------
+
+None
+
+Role Variables
+--------------
+
+None
+
+Dependencies
+------------
+
+None
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: all
+      roles:
+        - ansible-irods-icommands
+
+
+License
+-------
+
+See license.md
+
+Author Information
+------------------
+
+https://cyverse.org

--- a/ansible/roles/irods-icommands/license.md
+++ b/ansible/roles/irods-icommands/license.md
@@ -1,0 +1,37 @@
+Copyright (c) 2011, The Arizona Board of Regents on behalf of
+The University of Arizona
+
+All rights reserved.
+
+Developed by: iPlant Collaborative as a collaboration between
+participants at BIO5 at The University of Arizona (the primary hosting
+institution), Cold Spring Harbor Laboratory, The University of Texas at
+Austin, and individual contributors. Find out more at
+http://www.iplantcollaborative.org/.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of the iPlant Collaborative, BIO5, The University
+   of Arizona, Cold Spring Harbor Laboratory, The University of Texas at
+   Austin, nor the names of other contributors may be used to endorse or
+   promote products derived from this software without specific prior
+   written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ansible/roles/irods-icommands/meta/.galaxy_install_info
+++ b/ansible/roles/irods-icommands/meta/.galaxy_install_info
@@ -1,0 +1,1 @@
+{install_date: 'Thu Sep  8 22:21:37 2016', version: master}

--- a/ansible/roles/irods-icommands/meta/.galaxy_install_info
+++ b/ansible/roles/irods-icommands/meta/.galaxy_install_info
@@ -1,1 +1,1 @@
-{install_date: 'Thu Sep  8 22:21:37 2016', version: master}
+{install_date: 'Fri Sep  9 20:12:23 2016', version: master}

--- a/ansible/roles/irods-icommands/meta/main.yml
+++ b/ansible/roles/irods-icommands/meta/main.yml
@@ -1,0 +1,197 @@
+galaxy_info:
+  author: Chris Martin, Andre Mercer
+  description: Installs iRODS iCommands 4.1.9, including irodsFs
+  company: CyVerse
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: BSD
+
+  min_ansible_version: 2.1
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If travis integration is cofigured, only notification for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+
+  #
+  # Below are all platforms currently available. Just uncomment
+  # the ones that apply to your role. If you don't see your
+  # platform on this list, let us know and we'll get it added!
+  #
+  platforms:
+  - name: EL
+    versions:
+    - all
+    - 5
+    - 6
+    - 7
+  #- name: GenericUNIX
+  #  versions:
+  #  - all
+  #  - any
+  #- name: OpenBSD
+  #  versions:
+  #  - all
+  #  - 5.6
+  #  - 5.7
+  #  - 5.8
+  #  - 5.9
+  #  - 6.0
+  #- name: Fedora
+  #  versions:
+  #  - all
+  #  - 16
+  #  - 17
+  #  - 18
+  #  - 19
+  #  - 20
+  #  - 21
+  #  - 22
+  #  - 23
+  #- name: opensuse
+  #  versions:
+  #  - all
+  #  - 12.1
+  #  - 12.2
+  #  - 12.3
+  #  - 13.1
+  #  - 13.2
+  #- name: MacOSX
+  #  versions:
+  #  - all
+  #  - 10.10
+  #  - 10.11
+  #  - 10.12
+  #  - 10.7
+  #  - 10.8
+  #  - 10.9
+  #- name: IOS
+  #  versions:
+  #  - all
+  #  - any
+  #- name: Solaris
+  #  versions:
+  #  - all
+  #  - 10
+  #  - 11.0
+  #  - 11.1
+  #  - 11.2
+  #  - 11.3
+  #- name: SmartOS
+  #  versions:
+  #  - all
+  #  - any
+  #- name: eos
+  #  versions:
+  #  - all
+  #  - Any
+  #- name: Windows
+  #  versions:
+  #  - all
+  #  - 2012R2
+  #- name: Amazon
+  #  versions:
+  #  - all
+  #  - 2013.03
+  #  - 2013.09
+  #- name: GenericBSD
+  #  versions:
+  #  - all
+  #  - any
+  #- name: Junos
+  #  versions:
+  #  - all
+  #  - any
+  #- name: FreeBSD
+  #  versions:
+  #  - all
+  #  - 10.0
+  #  - 10.1
+  #  - 10.2
+  #  - 10.3
+  #  - 8.0
+  #  - 8.1
+  #  - 8.2
+  #  - 8.3
+  #  - 8.4
+  #  - 9.0
+  #  - 9.1
+  #  - 9.1
+  #  - 9.2
+  #  - 9.3
+  - name: Ubuntu
+    versions:
+  #  - all
+  #  - lucid
+  #  - maverick
+  #  - natty
+  #  - oneiric
+    - precise
+  #  - quantal
+  #  - raring
+  #  - saucy
+    - trusty
+  #  - utopic
+  #  - vivid
+  #  - wily
+    - xenial
+  #- name: SLES
+  #  versions:
+  #  - all
+  #  - 10SP3
+  #  - 10SP4
+  #  - 11
+  #  - 11SP1
+  #  - 11SP2
+  #  - 11SP3
+  #  - 11SP4
+  #  - 12
+  #  - 12SP1
+  #- name: GenericLinux
+  #  versions:
+  #  - all
+  #  - any
+  #- name: NXOS
+  #  versions:
+  #  - all
+  #  - any
+  #- name: Debian
+  #  versions:
+  #  - all
+  #  - etch
+  #  - jessie
+  #  - lenny
+  #  - sid
+  #  - squeeze
+  #  - stretch
+  #  - wheezy
+
+  galaxy_tags:
+    - irods
+    - icommands
+    - datastore
+    # List tags for your role here, one per line. A tag is
+    # a keyword that describes and categorizes the role.
+    # Users find roles by searching for tags. Be sure to
+    # remove the '[]' above if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of
+    # alphanumeric characters. Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line.
+  # Be sure to remove the '[]' above if you add dependencies
+  # to this list.

--- a/ansible/roles/irods-icommands/meta/main.yml
+++ b/ansible/roles/irods-icommands/meta/main.yml
@@ -1,3 +1,5 @@
+# This file was created from https://github.com/cyverse-ansible/ansible-role-template
+
 galaxy_info:
   author: Chris Martin, Andre Mercer
   description: Installs iRODS iCommands 4.1.9, including irodsFs

--- a/ansible/roles/irods-icommands/tasks/main.yml
+++ b/ansible/roles/irods-icommands/tasks/main.yml
@@ -1,0 +1,126 @@
+---
+
+- name: Gather OS-specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
+    - "{{ ansible_distribution }}.yml"
+    - "{{ ansible_os_family }}.yml"
+  tags:
+    - vars
+    - icommands-setup
+
+- name: Enable EPEL for CentOS 5
+  yum:
+    name: epel-release
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version < '6')
+  tags: icommands-setup
+
+- name: Install Python 2.6 for CentOS 5
+  yum:
+    name: python26
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version < '6')
+  tags: icommands-setup
+
+- name: Install FUSE dependencies for CentOS
+  yum: name={{ item }}
+  with_items:
+    - fuse
+    - fuse-libs
+  when: (ansible_distribution == "CentOS")
+  tags: icommands-setup
+
+- name: Set Python 2.6 for CentOS 5
+  set_fact: ansible_python_interpreter=/usr/bin/python2.6
+  changed_when: false
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version < '6')
+  tags: icommands-setup
+
+- name: Download iCommands archive for CentOS 5
+  get_url:
+    url: "{{ ICOMMANDS_URL }}"
+    dest: /tmp/{{ ICOMMANDS_TAR }}
+    validate_certs: false
+  changed_when: false
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version < '6')
+  tags: icommands-setup
+
+- name: Extract iCommands for CentOS 5
+  command: "tar -xvf /tmp/{{ ICOMMANDS_TAR }} -C {{ ICOMMANDS_DESTINATION }}"
+  changed_when: false
+  when: ansible_distribution == "CentOS" and ansible_distribution_major_version < '6'
+  tags: icommands-setup
+
+- name: Download irodsFs for CentOS 5
+  get_url:
+    url: "{{ IRODSFS_URL }}"
+    dest: "{{ IRODSFS_DESTINATION }}"
+    validate_certs: false
+    mode: a+x
+  changed_when: false
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version < '6')
+  tags: icommands-setup
+
+- name: Set distro default Python interpreter for CentOS 5
+  set_fact: ansible_python_interpreter=/usr/bin/python
+  changed_when: false
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version < '6')
+  tags: icommands-setup
+
+- name: Add iCommands to path for all users except root, for CentOS 5
+  lineinfile: dest=/etc/profile line='export PATH=$PATH:/opt/icommands'
+  when: ansible_distribution == "CentOS" and ansible_distribution_major_version < '6'
+  tags: icommands-setup
+
+- name: Add iCommands to path for root user, for CentOS 5
+  lineinfile: dest=/root/.bash_profile line='export PATH=$PATH:/opt/icommands'
+  when: ansible_distribution == "CentOS" and ansible_distribution_major_version < '6'
+  tags: icommands-setup
+
+- name: Delete old irodsFs and iCommands executables for non-CentOS 5
+  file: path={{ item }} state=absent
+  with_items:
+    - "{{ IRODSFS_DESTINATION }}"
+    - "{{ IRODSFS_LINK }}"
+    - "{{ ICOMMANDS_DESTINATION }}/icommands"
+  when: not (ansible_distribution == "CentOS" and ansible_distribution_major_version < '6')
+  tags: icommands-setup
+
+- name: Delete any broken soft links in /usr/local/bin
+  command: find -L {{ BIN_PATH }} -type l -delete
+  changed_when: false
+  when: not (ansible_distribution == "CentOS" and ansible_distribution_major_version < '6')
+  tags: icommands-setup
+
+- name: Register list of home directories for removing old path from .bashrc
+  command: "ls /home"
+  register: home_dirs
+  changed_when: false
+  tags: icommands-setup
+
+- name: Remove old iCommands path from all users' .bashrc for non-CentOS 5
+  lineinfile: dest=/home/{{ item }}/.bashrc line='export PATH=$PATH:/opt/icommands' state=absent
+  with_items: "{{ home_dirs.stdout_lines }}"
+  when: not (ansible_distribution == "CentOS" and ansible_distribution_major_version < '6')
+  tags: icommands-setup
+
+- name: Download installation package for non-CentOS 5
+  get_url:
+    url: "{{ ICOMMANDS_URL }}"
+    dest: /tmp/icommands-pkg.rpm
+  changed_when: false
+  when: not (ansible_distribution == "CentOS" and ansible_distribution_major_version < '6')
+  tags: icommands-setup
+
+- name: Install iCommands for Ubuntu
+  apt:
+    deb: /tmp/icommands-pkg.rpm
+  when: ansible_distribution == "Ubuntu"
+  tags: icommands-setup
+
+- name: Install iCommands for CentOS 6 and 7
+  yum:
+    name: /tmp/icommands-pkg.rpm
+    state: present
+  when: (ansible_distribution == "CentOS" and ansible_distribution_major_version > "5")
+  tags: icommands-setup

--- a/ansible/roles/irods-icommands/tasks/main.yml
+++ b/ansible/roles/irods-icommands/tasks/main.yml
@@ -68,12 +68,18 @@
   tags: icommands-setup
 
 - name: Add iCommands to path for all users except root, for CentOS 5
-  lineinfile: dest=/etc/profile line='export PATH=$PATH:/opt/icommands'
+  lineinfile:
+    dest: /etc/profile
+    line: 'export PATH=$PATH:/opt/icommands'
+    create: yes
   when: ansible_distribution == "CentOS" and ansible_distribution_major_version < '6'
   tags: icommands-setup
 
 - name: Add iCommands to path for root user, for CentOS 5
-  lineinfile: dest=/root/.bash_profile line='export PATH=$PATH:/opt/icommands'
+  lineinfile:
+    dest: /root/.bash_profile
+    line: 'export PATH=$PATH:/opt/icommands'
+    create: yes
   when: ansible_distribution == "CentOS" and ansible_distribution_major_version < '6'
   tags: icommands-setup
 

--- a/ansible/roles/irods-icommands/tests/inventory
+++ b/ansible/roles/irods-icommands/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/ansible/roles/irods-icommands/tests/test.yml
+++ b/ansible/roles/irods-icommands/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - role_under_test

--- a/ansible/roles/irods-icommands/vars/CentOS-5.yml
+++ b/ansible/roles/irods-icommands/vars/CentOS-5.yml
@@ -1,0 +1,10 @@
+IRODSFS_EXECUTABLE: irodsFs_v32.rhel5.x86_64
+IRODSFS_DESTINATION: /usr/local/bin/irodsFs
+IRODSFS_LINK: /usr/local/bin/irodsFs
+
+ICOMMANDS_TAR: icommands_v331.centos.x86_64.tar.bz2
+ICOMMANDS_DESTINATION: /opt
+BIN_PATH: /usr/local/bin
+
+ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/icommands_v331.centos.x86_64.tar.bz2
+IRODSFS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irodsFs_v32.rhel5.x86_64

--- a/ansible/roles/irods-icommands/vars/CentOS-6.yml
+++ b/ansible/roles/irods-icommands/vars/CentOS-6.yml
@@ -1,0 +1,9 @@
+IRODSFS_EXECUTABLE: irodsFs_v32.rhel5.x86_64
+IRODSFS_DESTINATION: /usr/local/bin/irodsFs.x86_64
+IRODSFS_LINK: /usr/local/bin/irodsFs
+
+ICOMMANDS_TAR: icommands_v331.centos.x86_64.tar.bz2
+ICOMMANDS_DESTINATION: /opt
+BIN_PATH: /usr/local/bin
+
+ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-centos6-x86_64.rpm

--- a/ansible/roles/irods-icommands/vars/CentOS-7.yml
+++ b/ansible/roles/irods-icommands/vars/CentOS-7.yml
@@ -1,0 +1,9 @@
+IRODSFS_EXECUTABLE: irodsFs_v32.rhel5.x86_64
+IRODSFS_DESTINATION: /usr/local/bin/irodsFs.x86_64
+IRODSFS_LINK: /usr/local/bin/irodsFs
+
+ICOMMANDS_TAR: icommands_v331.centos.x86_64.tar.bz2
+ICOMMANDS_DESTINATION: /opt
+BIN_PATH: /usr/local/bin
+
+ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-centos7-x86_64.rpm

--- a/ansible/roles/irods-icommands/vars/CentOS.yml
+++ b/ansible/roles/irods-icommands/vars/CentOS.yml
@@ -1,0 +1,9 @@
+IRODSFS_EXECUTABLE: irodsFs_v32.rhel5.x86_64
+IRODSFS_DESTINATION: /usr/local/bin/irodsFs.x86_64
+IRODSFS_LINK: /usr/local/bin/irodsFs
+
+ICOMMANDS_TAR: icommands_v331.centos.x86_64.tar.bz2
+ICOMMANDS_DESTINATION: /opt
+BIN_PATH: /usr/local/bin
+
+ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-centos6-x86_64.rpm

--- a/ansible/roles/irods-icommands/vars/Ubuntu-12.yml
+++ b/ansible/roles/irods-icommands/vars/Ubuntu-12.yml
@@ -1,0 +1,9 @@
+IRODSFS_EXECUTABLE: irodsFs_v32.ubuntu12.x86_64
+IRODSFS_DESTINATION: /usr/local/bin/irodsFs.x86_64
+IRODSFS_LINK: /usr/local/bin/irodsFs
+
+ICOMMANDS_TAR: icommands_v331.ubuntu.x86_64.tar.bz2
+ICOMMANDS_DESTINATION: /opt
+BIN_PATH: /usr/local/bin
+
+ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-ubuntu12-x86_64.deb

--- a/ansible/roles/irods-icommands/vars/Ubuntu-14.yml
+++ b/ansible/roles/irods-icommands/vars/Ubuntu-14.yml
@@ -1,0 +1,9 @@
+IRODSFS_EXECUTABLE: irodsFs_v32.ubuntu12.x86_64
+IRODSFS_DESTINATION: /usr/local/bin/irodsFs.x86_64
+IRODSFS_LINK: /usr/local/bin/irodsFs
+
+ICOMMANDS_TAR: icommands_v331.ubuntu.x86_64.tar.bz2
+ICOMMANDS_DESTINATION: /opt
+BIN_PATH: /usr/local/bin
+
+ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-ubuntu14-x86_64.deb

--- a/ansible/roles/irods-icommands/vars/Ubuntu-16.yml
+++ b/ansible/roles/irods-icommands/vars/Ubuntu-16.yml
@@ -1,0 +1,9 @@
+IRODSFS_EXECUTABLE: irodsFs_v32.ubuntu12.x86_64
+IRODSFS_DESTINATION: /usr/local/bin/irodsFs.x86_64
+IRODSFS_LINK: /usr/local/bin/irodsFs
+
+ICOMMANDS_TAR: icommands_v331.ubuntu.x86_64.tar.bz2
+ICOMMANDS_DESTINATION: /opt
+BIN_PATH: /usr/local/bin
+
+ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-ubuntu14-x86_64.deb

--- a/ansible/roles/irods-icommands/vars/Ubuntu.yml
+++ b/ansible/roles/irods-icommands/vars/Ubuntu.yml
@@ -1,0 +1,9 @@
+IRODSFS_EXECUTABLE: irodsFs_v32.ubuntu12.x86_64
+IRODSFS_DESTINATION: /usr/local/bin/irodsFs.x86_64
+IRODSFS_LINK: /usr/local/bin/irodsFs
+
+ICOMMANDS_TAR: icommands_v331.ubuntu.x86_64.tar.bz2
+ICOMMANDS_DESTINATION: /opt
+BIN_PATH: /usr/local/bin
+
+ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-ubuntu14-x86_64.deb


### PR DESCRIPTION
I have Galaxy-ized and built a test suite for the role that installs the new iCommands. In this PR, atmosphere-ansible now consumes the irods-icommands role from Ansible Galaxy, rather than maintaining its own separate code to install iCommands.

https://github.com/CyVerse-Ansible/ansible-irods-icommands

Idea 1 is that many of the Ansible roles that we write are broadly useful in many places, but we're multiplying the maintenance effort by developing them separately for Atmosphere, for core services, etc. In truth, we only need to maintain the "install iCommands" role _in one place_, for consumption by all CyVerse groups and the wider community. That place can be [cyverse-ansible](https://github.com/cyverse-ansible) and [Ansible Galaxy](https://galaxy.ansible.com).

Idea 2 is that our Ansible roles should have automated testing. Check it out: https://travis-ci.org/CyVerse-Ansible/ansible-irods-icommands

This test suite (as defined in `.travis.yml` in the Galaxy role) does the following _against all supported distros_ (except CentOS 5):
- Confirms correctness of the role syntax
- Runs the role to install iCommands, confirms no errors with playbook run
- Performs smoke testing of `ils` and `irodsFs` commands
- Runs the role again to test for idempotence

In the future, if we update the roles we consume in atmosphere-ansible by running `ansible-galaxy install -f -r requirements.yml -p roles/`, then the latest _passing_ build will end up in the atmosphere-ansible codebase (and in production).

I'd like to see us adopt the pattern of contributing modular roles to - and consuming roles from - [cyverse-ansible](https://github.com/cyverse-ansible) / [Ansible Galaxy](https://galaxy.ansible.com). It's a little more up-front effort but a DevOps win in the long run.
