### PR TITLE
Allowing deployers to prevent atmo-ansible from setting default NTP 

### DIFF
--- a/ansible/roles/atmo-ntp/defaults/main.yml
+++ b/ansible/roles/atmo-ntp/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
 
+SET_NTP_SERVERS: true
+
 NTP_SERVERS:
     - server 0.us.pool.ntp.org
     - server 1.us.pool.ntp.org

--- a/ansible/roles/atmo-ntp/tasks/main.yml
+++ b/ansible/roles/atmo-ntp/tasks/main.yml
@@ -65,6 +65,7 @@
     - "../templates/{{ ansible_os_family }}.ntp.conf.j2"
   tags:
     - template
+  when: SET_NTP_SERVERS == true
 
 - name: start ntp service
   action: >


### PR DESCRIPTION
@steve-gregory one more tweak incoming. (I was right on this PR the first time, pointing to the move-jetstream-to-cyverse-repo branch of upstream.)