### PR TITLE
Remove duplicate port entries in sshd_config

### DIFF
--- a/ansible/roles/atmo-ssh-setup/defaults/main.yml
+++ b/ansible/roles/atmo-ssh-setup/defaults/main.yml
@@ -19,10 +19,14 @@ SSHD_CHANGES:
     line: 'PasswordAuthentication yes'
     state: 'present'
 
-    # This regexp matches all 'Port ' entries that are not {{SSH_PORT}} and removes them
-  - regexp: '^Port (?!{{ SSH_PORT }}$)\d'
+    # This regexp matches any line containing 'Port' or 'port'
+  - regexp: '^[\s#]*[Pp]ort.*$'
     line: ''
     state: 'absent'
+
+  - regexp: '\Z'
+    line: 'Port {{ SSH_PORT }}'
+    state: 'present'
 
   - regexp: '^AllowGroups'
     line: 'AllowGroups {{ SSH_ALLOW_GROUPS }}'

--- a/ansible/roles/atmo-ssh-setup/defaults/main.yml
+++ b/ansible/roles/atmo-ssh-setup/defaults/main.yml
@@ -19,14 +19,6 @@ SSHD_CHANGES:
     line: 'PasswordAuthentication yes'
     state: 'present'
 
-  - regexp: '^#Port'
-    line: 'Port {{ SSH_PORT }}'
-    state: 'present'
-
-  - regexp: '^Port'
-    line: 'Port {{ SSH_PORT }}'
-    state: 'present'
-
     # This regexp matches all 'Port ' entries that are not {{SSH_PORT}} and removes them
   - regexp: '^Port (?!{{ SSH_PORT }}$)\d'
     line: ''

--- a/ansible/roles/atmo-ssh-setup/tasks/ssh-setup.yml
+++ b/ansible/roles/atmo-ssh-setup/tasks/ssh-setup.yml
@@ -26,14 +26,6 @@
   with_items:
     - "{{ SSHD_CHANGES }}"
 
-- name: Uncomment Port line if it is commented
-  lineinfile:
-    dest: /etc/ssh/sshd_config
-    regexp: "^#Port"
-    line: "Port {{ SSH_PORT }}"
-    state: present
-    backrefs: true
-
 - name: Restart SSH service
   service:
     name: "{{ SSH_SERVICE }}"

--- a/ansible/roles/atmo-ssh-setup/tasks/ssh-setup.yml
+++ b/ansible/roles/atmo-ssh-setup/tasks/ssh-setup.yml
@@ -26,6 +26,14 @@
   with_items:
     - "{{ SSHD_CHANGES }}"
 
+- name: Uncomment Port line if it is commented
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: "^#Port"
+    line: "Port {{ SSH_PORT }}"
+    state: present
+    backrefs: true
+
 - name: Restart SSH service
   service:
     name: "{{ SSH_SERVICE }}"


### PR DESCRIPTION
These changes will remove any non-22 port entry and will uncomment the default entry if it is commented. This is a fix for issue #29 

I added a new task for this lineinfile because I did not want to add `backrefs: false` to each dictionary in the list.

There are other ways to do this. If this isn't a preferred solution I can offer up another.

Also, since these changes are for a problem that occurs in specific images that have weird default `sshd_config` I believe it creates a good argument for a `sshd_config` template for more consistency.