### PR TITLE
Fix merged jetstream fork issues

### DIFF
--- a/ansible/playbooks/instance_deploy/42_globus_connect.yml
+++ b/ansible/playbooks/instance_deploy/42_globus_connect.yml
@@ -3,4 +3,4 @@
   hosts: atmosphere
   roles:
     # GLOBUS_ENDPOINT variable required
-    - { role: atmo-globus-connect, when: SETUP_GLOBUS_CONNECT is defined and SETUP_GLOBUS_CONNECT == true }
+    # - { role: atmo-globus-connect, when: SETUP_GLOBUS_CONNECT is defined and SETUP_GLOBUS_CONNECT == true }

--- a/ansible/roles/atmo-setup-user/tasks/main.yml
+++ b/ansible/roles/atmo-setup-user/tasks/main.yml
@@ -67,7 +67,8 @@
 
 - name: add ATMOUSERNAME to users group
   lineinfile: dest=/etc/group regexp='^(users:x:100:)(.*)' line="\1{{ ATMOUSERNAME }},\2" state=present backrefs=yes
-  when: 'user_not_present.rc == 1'
+  when:
+    - 'ADD_TO_GROUP is not defined'
   tags: debug-ssh
 
 - name: see if user is already located in docker group


### PR DESCRIPTION
I had to change these on Jetstream Test Cloud's Atmosphere(1) in order to get the atmosphere-ansible playbooks to run. The atmo-globus-connect role was broken and never called in Jetstream's old fork, but I've left the role call here (commented out) because we probably want to fix it soon.

Note that this doesn't solve the greater problem observed during mock deployment today (playbooks in the `instance_deploy` folder are not called by Atmosphere).