### PR TITLE
rsyslog must be restarted after changing time zone so that fail2ban works

### DIFF
--- a/ansible/roles/atmo-common/tasks/main.yml
+++ b/ansible/roles/atmo-common/tasks/main.yml
@@ -59,6 +59,11 @@
   tags:
     - timezone
 
+- name: Restart rsyslog so that logs are written with correct timezone
+  service:
+    name: rsyslog
+    state: restarted
+
 ########
 # MOTD #
 ########


### PR DESCRIPTION
fail2ban was not banning hosts despite repeated invalid SSH attempts, on both Ubuntu and CentOS instances. Turned on debug logging and saw this:

```
2017-02-21 15:16:44,054 fail2ban.datetemplate: DEBUG  Correcting deduced year from 2017 to 2016 since 1487722604.000000 > 1487715404.054877
2017-02-21 15:16:44,055 fail2ban.filter.datedetector: DEBUG  Got time using template MONTH Day Hour:Minute:Second
2017-02-21 15:16:44,055 fail2ban.filter : DEBUG  Processing line with time:1456100204.0 and ip:107.170.175.232
2017-02-21 15:16:44,055 fail2ban.filter : DEBUG  Ignore line since time 1456100204.0 < 1487715404.06 - 600
```

The files that log SSH connection attempts (`/var/log/auth.log` on Ubuntu, `/var/log/secure` on CentOS) showed timestamps 2 hours ahead of system time. Since the timestamps did not include a year, fail2ban assumed the events occured **"2 hours from now last year"**. Since fail2ban only registers failures on recent events (the past 600 seconds in our case), it ignored all failed SSH connection attempts and did not ban any hosts.

I ran into this issue while testing with images that were created by Jetstream Cloud / IU, so they were likely baked with Eastern time. atmosphere-ansible runs and switches the system to Arizona time, and we get in this inconsistent state.

**tl;dr** when the system time zone is changed, fail2ban picks up the new time automatically, but rsyslog needs to be restarted in order for log timestamps to match system time.