### PR TITLE
Fail2ban always started

### DIFF
--- a/ansible/roles/atmo-cleanup/vars/CentOS.yml
+++ b/ansible/roles/atmo-cleanup/vars/CentOS.yml
@@ -10,6 +10,7 @@ PROCESSES:
 
 SERVICES:
   enabled:
+    - fail2ban
     - sshd
     - iptables
     - ntpd
@@ -21,4 +22,3 @@ SERVICES:
     - hidd
     - isdn
     - avahi-daemon
-    

--- a/ansible/roles/atmo-cleanup/vars/Ubuntu.yml
+++ b/ansible/roles/atmo-cleanup/vars/Ubuntu.yml
@@ -10,6 +10,7 @@ PROCESSES:
 
 SERVICES:
   enabled:
+    - fail2ban
     - ssh
     - ufw
     - ntp
@@ -21,4 +22,3 @@ SERVICES:
     - hidd
     - isdn
     - avahi-daemon
-    

--- a/ansible/roles/atmo-common/tasks/main.yml
+++ b/ansible/roles/atmo-common/tasks/main.yml
@@ -59,6 +59,11 @@
   tags:
     - timezone
 
+- name: Restart rsyslog so that logs are written with correct timezone
+  service:
+    name: rsyslog
+    state: restarted
+
 ########
 # MOTD #
 ########

--- a/ansible/roles/atmo-fail2ban/tasks/main.yml
+++ b/ansible/roles/atmo-fail2ban/tasks/main.yml
@@ -43,7 +43,6 @@
     src: '{{ item }}'
     dest: '/etc/fail2ban/jail.local'
     mode: 0644
-  notify: 'fail2ban restarted'
   tags: 'fail2ban-configured'
   with_first_found:
     - '../templates/{{ ansible_distribution }}-{{ ansible_distribution_major_version}}-jail.local.j2'
@@ -101,8 +100,9 @@
   # I am unsure why we are only doing this for certain distros, carried over from before refactor
   when: 'ansible_distribution == "CentOS" and ansible_distribution_major_version < "7"'
 
-- name: 'fail2ban service enabled'
+- name: 'fail2ban service started and enabled'
   service:
     name: 'fail2ban'
+    state: started
     enabled: true
   tags: 'fail2ban-enabled'

--- a/ansible/roles/atmo-fail2ban/tasks/main.yml
+++ b/ansible/roles/atmo-fail2ban/tasks/main.yml
@@ -43,6 +43,7 @@
     src: '{{ item }}'
     dest: '/etc/fail2ban/jail.local'
     mode: 0644
+  notify: 'fail2ban restarted'
   tags: 'fail2ban-configured'
   with_first_found:
     - '../templates/{{ ansible_distribution }}-{{ ansible_distribution_major_version}}-jail.local.j2'


### PR DESCRIPTION
Depends on #71. CentOS images were deploying with fail2ban stopped. Apparently one of the other tasks in the atmo-fail2ban role stopped the service, and if we don't need to template out any changes to the jail config files, the service was never started again. This ensures fail2ban is started when we are done configuring it.