### PR TITLE
Updating irods-icommands role to 4.1.9-cv (CyVerse-optimized)

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,5 +1,8 @@
 ---
 
-# from Galaxy
+# Required roles from Ansible Galaxy
+# Install latest version of required Ansible roles by running the following:
+# ansible-galaxy install -f -r requirements.yml -p roles/
+
 - src: CyVerse-Ansible.irods-icommands
   name: irods-icommands

--- a/ansible/roles/irods-icommands/.travis.yml
+++ b/ansible/roles/irods-icommands/.travis.yml
@@ -1,0 +1,56 @@
+---
+language: python
+python: "2.7"
+
+sudo: required
+dist: trusty
+services:
+  - docker
+
+env:
+  - distribution: centos
+    version: 7
+  - distribution: centos
+    version: 6
+# No supported/sane way to run Ansible inside a CentOS 5 Docker container;
+#   - distribution: centos
+#     version: 5
+#     pkg_cmd: yum
+  - distribution: ubuntu
+    version: 16.04
+  - distribution: ubuntu
+    version: 14.04
+  - distribution: ubuntu
+    version: 12.04
+
+before_install:
+  - 'sudo docker run -it --name=test_dummy --privileged --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:rw cyverse/ansible-test:latest-${distribution}-${version} bash'
+
+script:
+  # Syntax check
+  - sudo docker exec test_dummy ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml -i tests/inventory --syntax-check
+
+  # Run playbook to install iCommands and irodsFs
+  - "sudo docker exec test_dummy ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml -i tests/inventory --connection=local"
+
+  # Smoke test that commands run
+  - >
+    sudo docker exec test_dummy irodsFs 2>&1 | grep -iq "fuse"
+    && (echo 'Test for irodsFs command: pass' && exit 0)
+    || (echo 'Test for irodsFs command: fail' && exit 1)
+
+  - >
+    sudo docker exec test_dummy ils 2>&1 | grep -q "USER_RODS_HOST_EMPTY"
+    && (echo 'Test for ils command: pass' && exit 0)
+    || (echo 'Test for ils command: fail' && exit 1)
+
+  # Idempotence test
+  - >
+    sudo docker exec test_dummy ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml -i tests/inventory --connection=local
+    | grep -q 'changed=0.*failed=0'
+    && (echo 'Idempotence test: pass' && exit 0)
+    || (echo 'Idempotence test: fail' && exit 1)
+
+
+notifications:
+    webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/ansible/roles/irods-icommands/meta/.galaxy_install_info
+++ b/ansible/roles/irods-icommands/meta/.galaxy_install_info
@@ -1,1 +1,1 @@
-{install_date: 'Fri Sep  9 20:12:23 2016', version: master}
+{install_date: 'Wed Feb 22 22:53:09 2017', version: master}

--- a/ansible/roles/irods-icommands/vars/CentOS-6.yml
+++ b/ansible/roles/irods-icommands/vars/CentOS-6.yml
@@ -6,4 +6,4 @@ ICOMMANDS_TAR: icommands_v331.centos.x86_64.tar.bz2
 ICOMMANDS_DESTINATION: /opt
 BIN_PATH: /usr/local/bin
 
-ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-centos6-x86_64.rpm
+ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-cv-64bit-centos6.rpm

--- a/ansible/roles/irods-icommands/vars/CentOS-7.yml
+++ b/ansible/roles/irods-icommands/vars/CentOS-7.yml
@@ -6,4 +6,4 @@ ICOMMANDS_TAR: icommands_v331.centos.x86_64.tar.bz2
 ICOMMANDS_DESTINATION: /opt
 BIN_PATH: /usr/local/bin
 
-ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-centos7-x86_64.rpm
+ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-cv-64bit-centos7.rpm

--- a/ansible/roles/irods-icommands/vars/CentOS.yml
+++ b/ansible/roles/irods-icommands/vars/CentOS.yml
@@ -6,4 +6,4 @@ ICOMMANDS_TAR: icommands_v331.centos.x86_64.tar.bz2
 ICOMMANDS_DESTINATION: /opt
 BIN_PATH: /usr/local/bin
 
-ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-centos6-x86_64.rpm
+ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-cv-64bit-centos6.rpm

--- a/ansible/roles/irods-icommands/vars/Ubuntu-12.yml
+++ b/ansible/roles/irods-icommands/vars/Ubuntu-12.yml
@@ -6,4 +6,4 @@ ICOMMANDS_TAR: icommands_v331.ubuntu.x86_64.tar.bz2
 ICOMMANDS_DESTINATION: /opt
 BIN_PATH: /usr/local/bin
 
-ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-ubuntu12-x86_64.deb
+ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-cv-64bit-ubuntu-12.deb

--- a/ansible/roles/irods-icommands/vars/Ubuntu-14.yml
+++ b/ansible/roles/irods-icommands/vars/Ubuntu-14.yml
@@ -6,4 +6,4 @@ ICOMMANDS_TAR: icommands_v331.ubuntu.x86_64.tar.bz2
 ICOMMANDS_DESTINATION: /opt
 BIN_PATH: /usr/local/bin
 
-ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-ubuntu14-x86_64.deb
+ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-cv-64bit-ubuntu-14.deb

--- a/ansible/roles/irods-icommands/vars/Ubuntu-16.yml
+++ b/ansible/roles/irods-icommands/vars/Ubuntu-16.yml
@@ -6,4 +6,4 @@ ICOMMANDS_TAR: icommands_v331.ubuntu.x86_64.tar.bz2
 ICOMMANDS_DESTINATION: /opt
 BIN_PATH: /usr/local/bin
 
-ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-ubuntu14-x86_64.deb
+ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-cv-64bit-ubuntu-14.deb

--- a/ansible/roles/irods-icommands/vars/Ubuntu.yml
+++ b/ansible/roles/irods-icommands/vars/Ubuntu.yml
@@ -6,4 +6,4 @@ ICOMMANDS_TAR: icommands_v331.ubuntu.x86_64.tar.bz2
 ICOMMANDS_DESTINATION: /opt
 BIN_PATH: /usr/local/bin
 
-ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-ubuntu14-x86_64.deb
+ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-cv-64bit-ubuntu-14.deb


### PR DESCRIPTION
See [ansible-irods-icommands #1](https://github.com/CyVerse-Ansible/ansible-irods-icommands/pull/1), tested and confident it works. These new iCommands packages use Ilyoung Choi's [recent performance tweaks](https://github.com/cyverse/cyverse-irods/commit/43835120a33a50f57eccb6b06fe5a829949bcd90).