### PR TITLE
Fix syslog service name on CentOS 5

### DIFF
--- a/ansible/roles/atmo-common/tasks/main.yml
+++ b/ansible/roles/atmo-common/tasks/main.yml
@@ -61,7 +61,7 @@
 
 - name: Restart rsyslog so that logs are written with correct timezone
   service:
-    name: rsyslog
+    name: '{{ SYSLOG_SERVICE_NAME }}'
     state: restarted
 
 ########

--- a/ansible/roles/atmo-common/vars/CentOS-5.yml
+++ b/ansible/roles/atmo-common/vars/CentOS-5.yml
@@ -21,7 +21,8 @@ PACKAGES:
   - python
   - python-ldap
 
+SYSLOG_SERVICE_NAME: syslog
 
 # Add modules to be loaded here
 #MODULES_TO_LOAD:
-#  - 
+#  -

--- a/ansible/roles/atmo-common/vars/CentOS-6.yml
+++ b/ansible/roles/atmo-common/vars/CentOS-6.yml
@@ -24,6 +24,8 @@ PACKAGES:
   - python-ldap
   - qemu-guest-agent
 
+SYSLOG_SERVICE_NAME: rsyslog
+
 # Add modules to be loaded here
 #MODULES_TO_LOAD:
-#  - 
+#  -

--- a/ansible/roles/atmo-common/vars/CentOS-7.yml
+++ b/ansible/roles/atmo-common/vars/CentOS-7.yml
@@ -27,6 +27,8 @@ PACKAGES:
   - vim
   - qemu-guest-agent
 
-# Add modules to be loaded here 
+SYSLOG_SERVICE_NAME: rsyslog
+
+# Add modules to be loaded here
 #MODULES_TO_LOAD:
 #  - acpiphp

--- a/ansible/roles/atmo-common/vars/Ubuntu-12.yml
+++ b/ansible/roles/atmo-common/vars/Ubuntu-12.yml
@@ -25,3 +25,5 @@ PACKAGES:
 
 MODULES_TO_LOAD:
   - acpiphp
+
+SYSLOG_SERVICE_NAME: rsyslog

--- a/ansible/roles/atmo-common/vars/Ubuntu-16.yml
+++ b/ansible/roles/atmo-common/vars/Ubuntu-16.yml
@@ -25,3 +25,5 @@ PACKAGES:
 # Add modules to be loaded here
 # MODULES_TO_LOAD:
 #   - acpiphp
+
+SYSLOG_SERVICE_NAME: rsyslog

--- a/ansible/roles/atmo-common/vars/Ubuntu.yml
+++ b/ansible/roles/atmo-common/vars/Ubuntu.yml
@@ -24,3 +24,5 @@ PACKAGES:
 
 MODULES_TO_LOAD:
   - acpiphp
+
+SYSLOG_SERVICE_NAME: rsyslog


### PR DESCRIPTION
I didn't bother testing #71 on CentOS 5 given its demise in a month. Sure enough, the next day someone reported that the fix breaks atmosphere-ansible when run against CentOS 5. CentOS 5 uses syslog, not rsyslog.