### PR TITLE
Problem: NTP_PREP_PACKAGE not installed

### DIFF
--- a/ansible/roles/atmo-ntp/tasks/main.yml
+++ b/ansible/roles/atmo-ntp/tasks/main.yml
@@ -32,12 +32,19 @@
   tags:
     - time
 
-- name: install ntp prep package(s)
+- name: install ntp prep package(s) -- Ubuntu only
+  shell: >
+    apt-get install {{ NTP_PREP_PACKAGE.name }}
+  tags:
+    - install
+  when: ansible_distribution == "Ubuntu" and NTP_PREP_PACKAGE is defined and NTP_PREP_PACKAGE.name != ""
+
+- name: install ntp prep package(s) -- Non-Ubuntu using action module
   action: >
     {{ ansible_pkg_mgr }} name={{ NTP_PREP_PACKAGE.name }} state={{ NTP_PREP_PACKAGE.state }}
   tags:
     - install
-  when: NTP_PREP_PACKAGE is defined and NTP_PREP_PACKAGE != ""
+  when: ansible_distribution != "Ubuntu" and NTP_PREP_PACKAGE is defined and NTP_PREP_PACKAGE != ""
 
 - name: install ntp package
   action: >


### PR DESCRIPTION
Solution: Use 'shell' instead of 'action'+'apt' for installing libssl1.0.0 (the NTP_PREP_PACKAGE)