### PR TITLE
Ubuntu 16.04 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Enable these optional configurations by setting the corresponding variable to `t
 | SETUP_IRODS_ICOMMANDS    | iRODS iCommands and iRODS FUSE client                     |
 | SETUP_REALVNC_SERVER     | RealVNC server for Atmosphere Web Desktop feature         |
 | SETUP_GLOBUS_CONNECT     | [Globus Connect](https://www.globus.org/globus-connect)   |
+| SETUP_GUI_BROWSER        | Web browser on instances with a GUI                       |
 
 ## Utility Playbooks
 

--- a/ansible/playbooks/instance_deploy/30_post_user_install.yml
+++ b/ansible/playbooks/instance_deploy/30_post_user_install.yml
@@ -5,5 +5,6 @@
   roles:
     - atmo-fail2ban
     - { role: irods-icommands, when: SETUP_IRODS_ICOMMANDS is defined and SETUP_IRODS_ICOMMANDS == true }
+    - { role: install-browser, when: SETUP_GUI_BROWSER is defined and SETUP_GUI_BROWSER == true }
     - { role: atmo-realvncserver, when: SETUP_REALVNC_SERVER is defined and SETUP_REALVNC_SERVER == true }
     - atmo-cleanup

--- a/ansible/roles/atmo-common/tasks/main.yml
+++ b/ansible/roles/atmo-common/tasks/main.yml
@@ -7,25 +7,6 @@
     - "{{ ansible_distribution }}.yml"
   tags: vars
 
-###################
-# Fix Chrome Repo #
-###################
-- name: check to see if outdated chrome repo exists
-  stat: path=/etc/apt/sources.list.d/google-chrome.list
-  when: ansible_distribution == "Ubuntu"
-  register: chrome_installed
-
-- name: fix chrome repo source list
-  shell: "{{ item }}"
-  ignore_errors: yes
-  failed_when: False
-  when: (ansible_distribution == "Ubuntu") and (chrome_installed.stat.exists)
-  with_items:
-    - sed -i -e 's/deb http/deb [arch=amd64] http/' "/etc/apt/sources.list.d/google-chrome.list"
-    - sed -i -e 's/deb http/deb [arch=amd64] http/' "/opt/google/chrome/cron/google-chrome"
-    - apt-get clean
-    - apt-get update
-
 ###########
 # Install #
 ###########

--- a/ansible/roles/atmo-dhcp/templates/hostname-exit-hook.sh.j2
+++ b/ansible/roles/atmo-dhcp/templates/hostname-exit-hook.sh.j2
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 PREFIX="{{ PREFIX }}"
 
@@ -49,7 +49,7 @@ hostname_value=""
 echo $(date +"%m%d%y %H:%M:%S") "dhclient hostname hook started" >> $LOG
 
 while [ $retry -lt $MAX_ATTEMPTS -a -z "$hostname_value" ]; do
-    ((retry++))
+    retry=$((retry+1))
     echo $(date +"%m%d%y %H:%M:%S") "	Attempt #${retry}" >> $LOG
     # Note: gobal hostname_value is returned
     get_hostname
@@ -59,7 +59,7 @@ done
 {% if ADD_EXTERNAL_IP_RESOLUTION_ATTEMPTS %}
 
 # attempt external ip resolution through dyndns
-if [[ -z $hostname_value ]]; then
+if [ -z $hostname_value ]; then
   myip=$(timeout -s SIGTERM 10 curl -s 'http://checkip.dyndns.org' | sed 's/.*Current IP Address: \([0-9\.]*\).*/\1/g')
   if [ $? -eq 0 -a -n "$myip" ]; then
     echo $(date +"%m%d%y %H:%M:%S") "	attempting to set using dyndns (found ip = $myip) " >> $LOG
@@ -71,7 +71,7 @@ if [[ -z $hostname_value ]]; then
 fi
 
 # attempt external ip resolution through ipify
-if [[ -z $hostname_value ]]; then
+if [ -z $hostname_value ]; then
   myip=$(curl https://api.ipify.org)
   if [ $? -eq 0 -a -n "$myip" ]; then
     echo $(date +"%m%d%y %H:%M:%S") "	attempting to set using ipify (found ip = $myip) " >> $LOG
@@ -85,9 +85,9 @@ fi
 {% endif %}
 
 # retest hostname value
-if [[ -z $hostname_value ]]; then
+if [ -z $hostname_value ]; then
     domainname=".$(dnsdomainname)"
-    if [ $domainname == ".(none)" ];then
+    if [ $domainname = ".(none)" ];then
         domainname=""
     fi
     third_octet=$(echo $myip | cut -f 3 -d '.')

--- a/ansible/roles/install-browser/tasks/install.yml
+++ b/ansible/roles/install-browser/tasks/install.yml
@@ -1,0 +1,6 @@
+---
+
+- name: install browser
+  package:
+    name: firefox
+    state: latest

--- a/ansible/roles/install-browser/tasks/main.yml
+++ b/ansible/roles/install-browser/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+
+- name: verify that X server exists
+  stat:
+    path: "{{ XGUI.xsession_path }}"
+  register: xsession
+  tags:
+    - check-gui
+
+- name: verify that xterm session exists
+  stat:
+    path: "{{ XGUI.xterm_path }}"
+  register: xterm
+  tags:
+    - check-gui
+
+- name: set flag for GUI systems
+  set_fact:
+    has_gui: "{{ xsession.stat.exists and xterm.stat.exists }}"
+  tags:
+    - check-gui
+
+- name: install browser
+  include: install.yml
+  when:
+    - has_gui
+  

--- a/ansible/roles/install-browser/tasks/main.yml
+++ b/ansible/roles/install-browser/tasks/main.yml
@@ -1,5 +1,13 @@
 ---
 
+- name: gather OS-specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
+    - "{{ ansible_distribution }}.yml"
+  tags:
+    - x
+
 - name: verify that X server exists
   stat:
     path: "{{ XGUI.xsession_path }}"
@@ -24,4 +32,3 @@
   include: install.yml
   when:
     - has_gui
-  

--- a/ansible/roles/install-browser/vars/CentOS.yml
+++ b/ansible/roles/install-browser/vars/CentOS.yml
@@ -1,0 +1,3 @@
+XGUI:
+  xsession_path: /usr/bin/xinit
+  xterm_path: /usr/bin/Xorg

--- a/ansible/roles/install-browser/vars/Ubuntu.yml
+++ b/ansible/roles/install-browser/vars/Ubuntu.yml
@@ -1,0 +1,3 @@
+XGUI:
+  xsession_path: /usr/bin/X
+  xterm_path: /usr/bin/xinit

--- a/ansible/roles/ldap/tasks/main.yml
+++ b/ansible/roles/ldap/tasks/main.yml
@@ -216,7 +216,10 @@
     - restart-dbus
 
 - name: restart dbus for Ubuntu 16.04 and later
-  service: name=dbus state=reloaded enabled=yes
+  service:
+    name: 'dbus'
+    state: 'reloaded'
+    enabled: 'yes'
   when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 16
   tags:
     - reload-dbus
@@ -244,4 +247,3 @@
   delay: 10
   tags:
     - verify-ldap
-

--- a/ansible/roles/ldap/tasks/main.yml
+++ b/ansible/roles/ldap/tasks/main.yml
@@ -21,7 +21,7 @@
 - name: install ldap packages
   action: >
     {{ ansible_pkg_mgr }} name={{ item }} state={{ LDAP_PACKAGES.state }}
-  with_items: '{{ LDAP_PACKAGES.packages }}'
+  with_items: "{{ LDAP_PACKAGES.packages }}"
   tags:
     - install
 
@@ -209,19 +209,32 @@
   tags:
     - restart-nslcd
 
-- name: restart dbus
+- name: restart dbus for pre-Ubuntu 16.04
   service: name=dbus state=restarted enabled=yes
-  when: ansible_distribution == "Ubuntu"
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int < 16
   tags:
     - restart-dbus
 
-- name: restart services again just to be safe
+- name: restart dbus for Ubuntu 16.04 and later
+  service: name=dbus state=reloaded enabled=yes
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 16
+  tags:
+    - reload-dbus
+
+- name: restart nscd and nslcd services again just to be safe
   shell: service {{ item }} restart
   with_items:
     - nscd
     - nslcd
-    - dbus
   when: ansible_distribution == "Ubuntu"
+
+- name: restart dbus again just to be safe for pre-Ubuntu 16.04
+  shell: service dbus restart
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int < 16
+
+- name: reload dbus again just to be safe for Ubuntu 16.04 and later
+  shell: systemctl reload dbus
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 16
 
 - name: loop until ldap connection is made, fails if it can't
   command: id {{ TEST_LDAP_USER }}
@@ -231,3 +244,4 @@
   delay: 10
   tags:
     - verify-ldap
+

--- a/ansible/roles/ldap/vars/Ubuntu-16.yml
+++ b/ansible/roles/ldap/vars/Ubuntu-16.yml
@@ -1,0 +1,20 @@
+LDAP_PACKAGES:
+  packages:
+    - ldap-utils
+    - libpam-ldap
+    - libnss-ldapd
+    - nss-updatedb
+    - libnss-db
+    - nslcd
+    - nscd
+  state: present
+
+LDAP_CONF_PATH: /etc/ldap.conf
+
+#SSSD_CONF_PATH: /etc/sssd/sssd.conf
+
+#LDAP_AUTHCONFIG: authconfig --enableldap --enableldapauth --enablemkhomedir --enablesssd --enablesssdauth --ldapserver=ldap.iplantc.org --ldapbasedn="dc=iplantcollaborative,dc=org" --passalgo=md5 --update
+
+LDAP_SERVICE: sssd
+
+TEST_LDAP_USER: mattd-test01


### PR DESCRIPTION
Issues fixed:
- Copied Previous LDAP fixes form [this branch](https://github.com/cyverse/atmosphere-ansible/tree/ubuntu1604fixes)
- had to port `hostname` DHCP exit script from `bash` to `dash` (more detail [here](https://pods.iplantcollaborative.org/jira/browse/ATMO-1555?focusedCommentId=58558&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-58630)). This fixes error where instance took a long time to reboot and did not have networking after reboot.

As part of this development/testing effort, I had to create a GUI base image for Ubuntu 16.04. We want to provide a web browser in GUI instances, but I think it's a bad idea to bake a browser into a Glance image, because it will quickly go out of date and be vulnerable to security issues, so I created a new role in atmosphere-ansible to deploy a web browser to new instances. Also found some unused Google Chrome repositories in atmosphere-ansible and removed them.

To do:
- [x] Test Ubuntu 16.04 with Jetstream-specific Ansible roles (local user account, DHCP client?)