### PR TITLE
Add role to install kanki-irodsclient

### DIFF
--- a/ansible/playbooks/instance_deploy/30_post_user_install.yml
+++ b/ansible/playbooks/instance_deploy/30_post_user_install.yml
@@ -5,7 +5,7 @@
   roles:
     - atmo-fail2ban
     - { role: irods-icommands, when: SETUP_IRODS_ICOMMANDS is defined and SETUP_IRODS_ICOMMANDS == true }
-    = { role: atmo-kanki-irodsclient, when: SETUP_IRODS_ICOMMANDS is defined and SETUP_IRODS_ICOMMANDS == true }
+    - { role: atmo-kanki-irodsclient, when: SETUP_IRODS_ICOMMANDS is defined and SETUP_IRODS_ICOMMANDS == true }
     - { role: install-browser, when: SETUP_GUI_BROWSER is defined and SETUP_GUI_BROWSER == true }
     - { role: atmo-realvncserver, when: SETUP_REALVNC_SERVER is defined and SETUP_REALVNC_SERVER == true }
     - atmo-cleanup

--- a/ansible/playbooks/instance_deploy/30_post_user_install.yml
+++ b/ansible/playbooks/instance_deploy/30_post_user_install.yml
@@ -5,6 +5,7 @@
   roles:
     - atmo-fail2ban
     - { role: irods-icommands, when: SETUP_IRODS_ICOMMANDS is defined and SETUP_IRODS_ICOMMANDS == true }
+    = { role: atmo-kanki-irodsclient, when: SETUP_IRODS_ICOMMANDS is defined and SETUP_IRODS_ICOMMANDS == true }
     - { role: install-browser, when: SETUP_GUI_BROWSER is defined and SETUP_GUI_BROWSER == true }
     - { role: atmo-realvncserver, when: SETUP_REALVNC_SERVER is defined and SETUP_REALVNC_SERVER == true }
     - atmo-cleanup

--- a/ansible/roles/atmo-kanki-irodsclient/files/kanki.desktop
+++ b/ansible/roles/atmo-kanki-irodsclient/files/kanki.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Version=1.0
+Name=kanki-irodsclient
+Comment=Open kanki
+Exec=/usr/bin/irodsclient %f
+Icon=/usr/share/icons/irodsclient.png
+Terminal=false
+Type=Application
+Categories=Utility;Application;

--- a/ansible/roles/atmo-kanki-irodsclient/tasks/main.yml
+++ b/ansible/roles/atmo-kanki-irodsclient/tasks/main.yml
@@ -103,4 +103,8 @@
       file:
         state: absent
         path: /tmp/kanki-irodsclient
-  when: has_gui and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version > 12) or (ansible_distribution == "CentOS" and ansible_distribution_major_version > 5))
+  when:
+    has_gui and
+    ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version != '12')
+    or
+    (ansible_distribution == "CentOS" and ansible_distribution_major_version != '5')

--- a/ansible/roles/atmo-kanki-irodsclient/tasks/main.yml
+++ b/ansible/roles/atmo-kanki-irodsclient/tasks/main.yml
@@ -1,0 +1,86 @@
+---
+
+- name: Gather OS specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
+    - "{{ ansible_distribution }}.yml"
+
+- name: Install dependencies
+  package:
+    state: present
+    name: "{{ item }}"
+  with_items: "{{ dependencies }}"
+
+- name: Install iRods on CentOS
+  yum:
+    state: present
+    pkg: "{{ item }}"
+  with_items: "{{ irods_files }}"
+  when: ansible_distribution == "CentOS"
+
+- name: Install iRods on Ubuntu
+  apt:
+    state: present
+    deb: "{{ item }}"
+  with_items: "{{ irods_files }}"
+  when: ansible_distribution == "Ubuntu"
+
+- name: Create ~/.irods directory
+  file:
+    state: directory
+    path: "/home/{{ ATMOUSERNAME }}/.irods"
+    owner: "{{ ATMOUSERNAME }}"
+
+- name: Create /etc/irods directory
+  file:
+    state: directory
+    path: "/etc/irods"
+
+- name: Template irods_environment.json
+  template:
+    dest: "/home/{{ ATMOUSERNAME }}/.irods/irods_environment.json"
+    src: irods_environment.json.j2
+    owner: "{{ ATMOUSERNAME }}"
+
+- name: Download git repository
+  git:
+    repo: https://github.com/ilarik/kanki-irodsclient.git
+    dest: /tmp/kanki-irodsclient
+
+- name: Build kanki-irodsclient
+  command: "{{ build_cmd }}"
+  args:
+    chdir: /tmp/kanki-irodsclient/
+
+- name: Copy binary to PATH
+  copy:
+    remote_src: True
+    src: /tmp/kanki-irodsclient/src/irodsclient
+    dest: /usr/bin/irodsclient
+    mode: 0755
+
+- name: Copy schema.xml over
+  copy:
+    remote_src: True
+    src: /tmp/kanki-irodsclient/src/schema.xml
+    dest: /etc/irods/schema.xml
+    mode: 0644
+
+- name: Copy icon image
+  copy:
+    remote_src: True
+    src: /tmp/kanki-irodsclient/src/icons/irodsclient.png
+    dest: /usr/share/icons/irodsclient.png
+
+- name: Copy desktop launcher
+  copy:
+    src: files/kanki.desktop
+    dest: "/home/{{ ATMOUSERNAME }}/Desktop/kanki.desktop"
+    owner: "{{ ATMOUSERNAME }}"
+    mode: 0755
+
+- name: Remove git repository
+  file:
+    state: absent
+    path: /tmp/kanki-irodsclient

--- a/ansible/roles/atmo-kanki-irodsclient/tasks/main.yml
+++ b/ansible/roles/atmo-kanki-irodsclient/tasks/main.yml
@@ -99,6 +99,13 @@
         owner: "{{ ATMOUSERNAME }}"
         mode: 0755
 
+    - name: Copy application menu launcher
+      copy:
+        src: files/kanki.desktop
+        dest: "/usr/share/applications/kanki.desktop"
+        owner: root
+        mode: 0644
+
     - name: Remove git repository
       file:
         state: absent

--- a/ansible/roles/atmo-kanki-irodsclient/tasks/main.yml
+++ b/ansible/roles/atmo-kanki-irodsclient/tasks/main.yml
@@ -73,6 +73,11 @@
     src: /tmp/kanki-irodsclient/src/icons/irodsclient.png
     dest: /usr/share/icons/irodsclient.png
 
+- name: Make sure Desktop directory exists
+  file:
+    state: directory
+    path: "/home/{{ ATMOUSERNAME }}/Desktop"
+
 - name: Copy desktop launcher
   copy:
     src: files/kanki.desktop

--- a/ansible/roles/atmo-kanki-irodsclient/tasks/main.yml
+++ b/ansible/roles/atmo-kanki-irodsclient/tasks/main.yml
@@ -1,91 +1,93 @@
 ---
 
-- name: Gather OS specific variables
-  include_vars: "{{ item }}"
-  with_first_found:
-    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
-    - "{{ ansible_distribution }}.yml"
+- block:
+    - name: Gather OS specific variables
+      include_vars: "{{ item }}"
+      with_first_found:
+        - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
+        - "{{ ansible_distribution }}.yml"
 
-- name: Install dependencies
-  package:
-    state: present
-    name: "{{ item }}"
-  with_items: "{{ dependencies }}"
+    - name: Install dependencies
+      package:
+        state: present
+        name: "{{ item }}"
+      with_items: "{{ dependencies }}"
 
-- name: Install iRods on CentOS
-  yum:
-    state: present
-    pkg: "{{ item }}"
-  with_items: "{{ irods_files }}"
-  when: ansible_distribution == "CentOS"
+    - name: Install iRods on CentOS
+      yum:
+        state: present
+        pkg: "{{ item }}"
+      with_items: "{{ irods_files }}"
+      when: ansible_distribution == "CentOS"
 
-- name: Install iRods on Ubuntu
-  apt:
-    state: present
-    deb: "{{ item }}"
-  with_items: "{{ irods_files }}"
-  when: ansible_distribution == "Ubuntu"
+    - name: Install iRods on Ubuntu
+      apt:
+        state: present
+        deb: "{{ item }}"
+      with_items: "{{ irods_files }}"
+      when: ansible_distribution == "Ubuntu"
 
-- name: Create ~/.irods directory
-  file:
-    state: directory
-    path: "/home/{{ ATMOUSERNAME }}/.irods"
-    owner: "{{ ATMOUSERNAME }}"
+    - name: Create ~/.irods directory
+      file:
+        state: directory
+        path: "/home/{{ ATMOUSERNAME }}/.irods"
+        owner: "{{ ATMOUSERNAME }}"
 
-- name: Create /etc/irods directory
-  file:
-    state: directory
-    path: "/etc/irods"
+    - name: Create /etc/irods directory
+      file:
+        state: directory
+        path: "/etc/irods"
 
-- name: Template irods_environment.json
-  template:
-    dest: "/home/{{ ATMOUSERNAME }}/.irods/irods_environment.json"
-    src: irods_environment.json.j2
-    owner: "{{ ATMOUSERNAME }}"
+    - name: Template irods_environment.json
+      template:
+        dest: "/home/{{ ATMOUSERNAME }}/.irods/irods_environment.json"
+        src: irods_environment.json.j2
+        owner: "{{ ATMOUSERNAME }}"
 
-- name: Download git repository
-  git:
-    repo: https://github.com/ilarik/kanki-irodsclient.git
-    dest: /tmp/kanki-irodsclient
+    - name: Download git repository
+      git:
+        repo: https://github.com/ilarik/kanki-irodsclient.git
+        dest: /tmp/kanki-irodsclient
 
-- name: Build kanki-irodsclient
-  command: "{{ build_cmd }}"
-  args:
-    chdir: /tmp/kanki-irodsclient/
+    - name: Build kanki-irodsclient
+      command: "{{ build_cmd }}"
+      args:
+        chdir: /tmp/kanki-irodsclient/
 
-- name: Copy binary to PATH
-  copy:
-    remote_src: True
-    src: /tmp/kanki-irodsclient/src/irodsclient
-    dest: /usr/bin/irodsclient
-    mode: 0755
+    - name: Copy binary to PATH
+      copy:
+        remote_src: True
+        src: /tmp/kanki-irodsclient/src/irodsclient
+        dest: /usr/bin/irodsclient
+        mode: 0755
 
-- name: Copy schema.xml over
-  copy:
-    remote_src: True
-    src: /tmp/kanki-irodsclient/src/schema.xml
-    dest: /etc/irods/schema.xml
-    mode: 0644
+    - name: Copy schema.xml over
+      copy:
+        remote_src: True
+        src: /tmp/kanki-irodsclient/src/schema.xml
+        dest: /etc/irods/schema.xml
+        mode: 0644
 
-- name: Copy icon image
-  copy:
-    remote_src: True
-    src: /tmp/kanki-irodsclient/src/icons/irodsclient.png
-    dest: /usr/share/icons/irodsclient.png
+    - name: Copy icon image
+      copy:
+        remote_src: True
+        src: /tmp/kanki-irodsclient/src/icons/irodsclient.png
+        dest: /usr/share/icons/irodsclient.png
 
-- name: Make sure Desktop directory exists
-  file:
-    state: directory
-    path: "/home/{{ ATMOUSERNAME }}/Desktop"
+    - name: Make sure Desktop directory exists
+      file:
+        state: directory
+        path: "/home/{{ ATMOUSERNAME }}/Desktop"
 
-- name: Copy desktop launcher
-  copy:
-    src: files/kanki.desktop
-    dest: "/home/{{ ATMOUSERNAME }}/Desktop/kanki.desktop"
-    owner: "{{ ATMOUSERNAME }}"
-    mode: 0755
+    - name: Copy desktop launcher
+      copy:
+        src: files/kanki.desktop
+        dest: "/home/{{ ATMOUSERNAME }}/Desktop/kanki.desktop"
+        owner: "{{ ATMOUSERNAME }}"
+        mode: 0755
 
-- name: Remove git repository
-  file:
-    state: absent
-    path: /tmp/kanki-irodsclient
+    - name: Remove git repository
+      file:
+        state: absent
+        path: /tmp/kanki-irodsclient
+  when: (ansible_distribution_major_version == "Ubuntu" and ansible_distribution_major_version > 12) or (ansible_distribution_major_version == "CentOS" and ansible_distribution_major_version > 5)

--- a/ansible/roles/atmo-kanki-irodsclient/tasks/main.yml
+++ b/ansible/roles/atmo-kanki-irodsclient/tasks/main.yml
@@ -1,12 +1,25 @@
 ---
 
-- block:
-    - name: Gather OS specific variables
-      include_vars: "{{ item }}"
-      with_first_found:
-        - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
-        - "{{ ansible_distribution }}.yml"
+- name: Gather OS specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
+    - "{{ ansible_distribution }}.yml"
 
+- name: verify that X server exists
+  stat:
+    path: "{{ xsession_path }}"
+  register: xsession
+
+- name: verify that xterm session exists
+  stat:
+    path: "{{ xterm_path }}"
+  register: xterm
+
+- name: set flag for GUI systems
+  set_fact: has_gui="{{ xsession.stat.exists and xterm.stat.exists }}"
+
+- block:
     - name: Install dependencies
       package:
         state: present
@@ -90,4 +103,4 @@
       file:
         state: absent
         path: /tmp/kanki-irodsclient
-  when: (ansible_distribution_major_version == "Ubuntu" and ansible_distribution_major_version > 12) or (ansible_distribution_major_version == "CentOS" and ansible_distribution_major_version > 5)
+  when: has_gui and ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version > 12) or (ansible_distribution == "CentOS" and ansible_distribution_major_version > 5))

--- a/ansible/roles/atmo-kanki-irodsclient/tasks/main.yml
+++ b/ansible/roles/atmo-kanki-irodsclient/tasks/main.yml
@@ -107,4 +107,4 @@
     has_gui and
     ((ansible_distribution == "Ubuntu" and ansible_distribution_major_version != '12')
     or
-    (ansible_distribution == "CentOS" and ansible_distribution_major_version != '5')
+    (ansible_distribution == "CentOS" and ansible_distribution_major_version != '5'))

--- a/ansible/roles/atmo-kanki-irodsclient/templates/irods_environment.json.j2
+++ b/ansible/roles/atmo-kanki-irodsclient/templates/irods_environment.json.j2
@@ -1,0 +1,7 @@
+{
+    "irods_host": "data.cyverse.org",
+    "irods_port": 1247,
+    "irods_user_name": "{{ ATMOUSERNAME }}",
+    "irods_zone_name": "iplant",
+    "irods_default_resource" : "CyVerseRes"
+}

--- a/ansible/roles/atmo-kanki-irodsclient/vars/CentOS.yml
+++ b/ansible/roles/atmo-kanki-irodsclient/vars/CentOS.yml
@@ -1,0 +1,40 @@
+---
+
+dependencies:
+  - epel-release
+  - openssl-devel
+  - libcurl-devel
+  - qt5-qtsvg-devel
+  - qt5-qtbase-devel
+  # instead of `yum groupinstall "Development Tools"`:
+  - bison
+  - byacc
+  - cscope
+  - ctags
+  - cvs
+  - diffstat
+  - doxygen
+  - flex
+  - gcc
+  - gcc-c++
+  - gcc-gfortran
+  - gettext
+  - git
+  - indent
+  - intltool
+  - libtool
+  - patch
+  - patchutils
+  - rcs
+  - redhat-rpm-config
+  - rpm-build
+  - subversion
+  - swig
+  - systemtap
+
+irods_files:
+  - ftp://ftp.renci.org/pub/irods/releases/4.1.9/centos6/irods-runtime-4.1.9-centos6-x86_64.rpm
+  - ftp://ftp.renci.org/pub/irods/releases/4.1.9/centos6/irods-icommands-4.1.9-centos6-x86_64.rpm
+  - ftp://ftp.renci.org/pub/irods/releases/4.1.9/centos6/irods-dev-4.1.9-centos6-x86_64.rpm
+
+build_cmd: ./build.sh

--- a/ansible/roles/atmo-kanki-irodsclient/vars/CentOS.yml
+++ b/ansible/roles/atmo-kanki-irodsclient/vars/CentOS.yml
@@ -1,5 +1,8 @@
 ---
 
+xsession_path: /usr/bin/xinit
+xterm_path: /usr/bin/Xorg
+
 dependencies:
   - epel-release
   - openssl-devel

--- a/ansible/roles/atmo-kanki-irodsclient/vars/Ubuntu.yml
+++ b/ansible/roles/atmo-kanki-irodsclient/vars/Ubuntu.yml
@@ -1,5 +1,8 @@
 ---
 
+xsession_path: /usr/bin/X
+xterm_path: /usr/bin/xinit
+
 dependencies:
   - git
   - qt5-qmake

--- a/ansible/roles/atmo-kanki-irodsclient/vars/Ubuntu.yml
+++ b/ansible/roles/atmo-kanki-irodsclient/vars/Ubuntu.yml
@@ -1,0 +1,16 @@
+---
+
+dependencies:
+  - git
+  - qt5-qmake
+  - qtbase5-dev
+  - libqt5svg5-dev
+  - libcurl4-nss-dev
+  - qt5-default
+
+irods_files:
+  - ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-runtime-4.1.9-ubuntu14-x86_64.deb
+  - ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-icommands-4.1.9-ubuntu14-x86_64.deb
+  - ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-dev-4.1.9-ubuntu14-x86_64.deb
+
+build_cmd: ./build.sh -q /usr/lib/x86_64-linux-gnu/qt5


### PR DESCRIPTION
This PR installs [kanki-irodsclient](https://github.com/ilarik/kanki-irodsclient), prepares the user's `irods_environment.json`, and creates a desktop and application menu launchers for the application (*it even has an icon!*). User's have to login first by using the `iinit` command and entering their password. I submitted a PR to improve the error message so new users will know how to login, hopefully it gets merged. The application is only installed on instances that have GUI.

Currently tested on:
- [x] Ubuntu 14.04.2 XFCE Base 
- [x] Ubuntu 14.04.3 NoGUI Base
- [x] Ubuntu 14.04 with Docker 1.7.x
- [x] CyVerse CentOS 6.8 GUI Base
- [x] iPlant Centos 6.5 NoGUI Base3

These two fail because`qt5-default` package is missing (12.04 is EOL, and kanki-irodsclient doesn't show support for 12.04):
- Ubuntu 12.04 Unity GUI
- functional genomics_v1.0

To prevent the failure, the role does not run on Ubuntu 12 and CentOS 5.