### PR TITLE
Add task for Ubuntu 16 background image

### DIFF
--- a/ansible/roles/atmo-realvncserver/tasks/main.yml
+++ b/ansible/roles/atmo-realvncserver/tasks/main.yml
@@ -90,6 +90,8 @@
         gconftool-2 -s -t string /desktop/gnome/background/picture_filename "/usr/share/backgrounds/cloud_background.jpg"
       when: ansible_distribution == "CentOS"
 
+    # Note: These tasks trick the os by replacing their defaults with our own instead of properly
+    # setting the background because "Unable to autolaunch a dbus-daemon without a $DISPLAY for X11"
     - name: Change desktop background on Ubuntu
       copy:
         src: /usr/share/backgrounds/cloud_background.jpg
@@ -97,10 +99,12 @@
         remote_src: True
       when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version < "16"
 
-  - name: Change desktop background on Ubuntu 16+
-    command: >
-      xfconf-query -c xfce4-desktop -p /backdrop/screen0/monitor0/wokspace0/last-image -s /usr/share/backgrounds/cloud_background.jpg
-    when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= "16"
+    - name: Change desktop background on Ubuntu 16+
+      copy:
+        src: /usr/share/backgrounds/cloud_background.jpg
+        dest: /usr/share/backgrounds/xfce/xfce-teal.jpg
+        remote_src: True
+      when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= "16"
 
   when: has_gui
 

--- a/ansible/roles/atmo-realvncserver/tasks/main.yml
+++ b/ansible/roles/atmo-realvncserver/tasks/main.yml
@@ -95,7 +95,13 @@
         src: /usr/share/backgrounds/cloud_background.jpg
         dest: /usr/share/backgrounds/default.jpg
         remote_src: True
-      when: ansible_distribution == "Ubuntu"
+      when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version < "16"
+
+  - name: Change desktop background on Ubuntu 16+
+    command: >
+      xfconf-query -c xfce4-desktop -p /backdrop/screen0/monitor0/wokspace0/last-image -s /usr/share/backgrounds/cloud_background.jpg
+    when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= "16"
+
   when: has_gui
 
 - name: remove locks and un-needed files


### PR DESCRIPTION
This PR adds a task to `atmo-realvncserver` to change the background image on XFCE 4 Ubuntu 16 images.