### PR TITLE
Fix kanki-irods role to work on Ubuntu 16.04

### DIFF
--- a/ansible/roles/atmo-kanki-irodsclient/vars/Ubuntu.yml
+++ b/ansible/roles/atmo-kanki-irodsclient/vars/Ubuntu.yml
@@ -10,6 +10,7 @@ dependencies:
   - libqt5svg5-dev
   - libcurl4-nss-dev
   - qt5-default
+  - g++
 
 irods_files:
   - ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-runtime-4.1.9-ubuntu14-x86_64.deb


### PR DESCRIPTION
Ubuntu 16 images require the `g++` package to properly compile irodsclient.