### PR TITLE
Variable to control desktop background changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Enable these optional configurations by setting the corresponding variable to `t
 | SETUP_REALVNC_SERVER     | RealVNC server for Atmosphere Web Desktop feature         |
 | SETUP_GLOBUS_CONNECT     | [Globus Connect](https://www.globus.org/globus-connect)   |
 | SETUP_GUI_BROWSER        | Web browser on instances with a GUI                       |
+| SET_DESKTOP_BACKGROUND   | Change desktop background for CyVerse but not Jetstream   |
 
 ## Utility Playbooks
 

--- a/ansible/roles/atmo-realvncserver/defaults/main.yml
+++ b/ansible/roles/atmo-realvncserver/defaults/main.yml
@@ -3,3 +3,5 @@
 REALVNC_SERVER_PERMISSIONS: 'root:f,:f'
 
 background_img: 'files/atmosphere_wallpaper_v1.jpg'
+
+SET_DESKTOP_BACKGROUND: true

--- a/ansible/roles/atmo-realvncserver/tasks/main.yml
+++ b/ansible/roles/atmo-realvncserver/tasks/main.yml
@@ -89,6 +89,7 @@
       command: >
         gconftool-2 -s -t string /desktop/gnome/background/picture_filename "/usr/share/backgrounds/cloud_background.jpg"
       when: ansible_distribution == "CentOS"
+      ignore_errors: yes
 
     # Note: These tasks trick the os by replacing their defaults with our own instead of properly
     # setting the background because "Unable to autolaunch a dbus-daemon without a $DISPLAY for X11"
@@ -98,6 +99,7 @@
         dest: /usr/share/backgrounds/default.jpg
         remote_src: True
       when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version < "16"
+      ignore_errors: yes
 
     - name: Change desktop background on Ubuntu 16+
       copy:
@@ -105,6 +107,7 @@
         dest: /usr/share/backgrounds/xfce/xfce-teal.jpg
         remote_src: True
       when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= "16"
+      ignore_errors: yes
 
   when: has_gui and SET_DESKTOP_BACKGROUND is defined and SET_DESKTOP_BACKGROUND == true
 

--- a/ansible/roles/atmo-realvncserver/tasks/main.yml
+++ b/ansible/roles/atmo-realvncserver/tasks/main.yml
@@ -106,7 +106,7 @@
         remote_src: True
       when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= "16"
 
-  when: has_gui
+  when: has_gui and SET_DESKTOP_BACKGROUND is defined and SET_DESKTOP_BACKGROUND == true
 
 - name: remove locks and un-needed files
   shell: /bin/rm -rf {{ item.PATH }}


### PR DESCRIPTION
From a conversation with @c-mart, Jetstream experiences failures with some instances because of the desktop background changes. The addition of the variable will allow Jetstream to avoid this. Also, ignore errors when these tasks fail bc it is not a fatal error.

### Todo
- [x] Add variable to other repos