### PR TITLE
Problem: deploy_ready fails on invalid host key

### DIFF
--- a/ansible/roles/check_networking/tasks/main.yml
+++ b/ansible/roles/check_networking/tasks/main.yml
@@ -56,9 +56,9 @@
 - name: fail when ssh errors occur related to Host key verification failed.
   fail:
     msg: "Configuration Error: Host key verification failed for IP: {{vm_ip}} . Does your ssh/config have 'StrictHostKeyChecking no' for the IP/IP Range/*"
-  when: (default_remote_user.stderr is defined and default_remote_user.stderr == "Host key verification failed.") and
-        (centos_remote_user.stderr is defined and centos_remote_user.stderr == "Host key verification failed.") and
-        (ubuntu_remote_user.stderr is defined and ubuntu_remote_user.stderr == "Host key verification failed.")
+  when: (default_remote_user.stderr is defined and "Host key verification failed." in  default_remote_user.stderr) and
+        (centos_remote_user.stderr is defined and  "Host key verification failed." in centos_remote_user.stderr) and
+        (ubuntu_remote_user.stderr is defined and  "Host key verification failed." in ubuntu_remote_user.stderr)
 
 - name: fail when ssh not possible
   fail: msg="The host is not reachable via SSH as root and cloud users."

--- a/ansible/roles/check_networking/tasks/main.yml
+++ b/ansible/roles/check_networking/tasks/main.yml
@@ -53,6 +53,13 @@
 # - debug: msg="ubuntu output is {{ ubuntu_remote_user.stdout }} and err is {{ ubuntu_remote_user.stderr }}"
 #   when: default_remote_user|failed and centos_remote_user|failed
 
+- name: fail when ssh errors occur related to Host key verification failed.
+  fail:
+    msg: "Configuration Error: Host key verification failed for IP: {{vm_ip}} . Does your ssh/config have 'StrictHostKeyChecking no' for the IP/IP Range/*"
+  when: (default_remote_user.stderr is defined and default_remote_user.stderr == "Host key verification failed.") and
+        (centos_remote_user.stderr is defined and centos_remote_user.stderr == "Host key verification failed.") and
+        (ubuntu_remote_user.stderr is defined and ubuntu_remote_user.stderr == "Host key verification failed.")
+
 - name: fail when ssh not possible
   fail: msg="The host is not reachable via SSH as root and cloud users."
   when: (default_remote_user.stdout is defined and default_remote_user.stdout != "hello") and


### PR DESCRIPTION
Solution: Check the stderr results for each user tested in
'check_networking'. If all show 'host key verification failed' then
inform the user there is a misconfiguration and provide a solution to
fix the configuration.