### PR TITLE
Change vncserver executable

### DIFF
--- a/ansible/roles/atmo-vnc/defaults/main.yml
+++ b/ansible/roles/atmo-vnc/defaults/main.yml
@@ -6,7 +6,7 @@ background_img: 'files/atmosphere_wallpaper_v1.jpg'
 
 SET_DESKTOP_BACKGROUND: false
 
-VNC_EXECUTABLE: "/usr/bin/vncserver-virtual"
+VNC_EXECUTABLE: "/usr/bin/vncserver"
 
 VNC_COMMANDS:
   realvnc:

--- a/ansible/roles/atmo-vnc/defaults/main.yml
+++ b/ansible/roles/atmo-vnc/defaults/main.yml
@@ -6,17 +6,19 @@ background_img: 'files/atmosphere_wallpaper_v1.jpg'
 
 SET_DESKTOP_BACKGROUND: false
 
+VNC_EXECUTABLE: "/usr/bin/vncserver-virtual"
+
 VNC_COMMANDS:
   realvnc:
     - "/usr/bin/pkill gnome-screensaver"
     - '/usr/bin/vnclicense -add {{ VNCLICENSE }}'
     - /bin/su {{ ATMOUSERNAME }} -c "/usr/bin/printf '%s\n%s\n' 'display' 'display' | vncpasswd /home/{{ ATMOUSERNAME }}/.vnc/config.d/Xvnc"
-    - "/bin/su {{ ATMOUSERNAME }} -c '/usr/bin/vncserver :1 -SecurityTypes=RA2'"
+    - "/bin/su {{ ATMOUSERNAME }} -c '{{ VNC_EXECUTABLE }} :1 -SecurityTypes=RA2'"
   novnc:
     - "/usr/bin/pkill gnome-screensaver"
     - "/usr/bin/pkill websockify"
     - "for i in $(/usr/bin/pgrep -f '/opt/kanaka-noVNC-8b0a0f6/utils/');do /bin/echo 'killing process:' $i; /bin/kill -HUP $i;done"
-    - "/bin/su {{ ATMOUSERNAME }} -c '/usr/bin/vncserver -localhost :{{ NOVNC.vnc_session }} -SecurityTypes=VNCAuth,TLSVnc'"
+    - "/bin/su {{ ATMOUSERNAME }} -c '{{ VNC_EXECUTABLE }} -localhost :{{ NOVNC.vnc_session }} -SecurityTypes=VNCAuth,TLSVnc'"
     # To disable NoVNC web when entering prod, remove "--web /usr/share/novnc/" from the command below
 
 NOVNC:

--- a/ansible/roles/atmo-vnc/tasks/guacamole.yml
+++ b/ansible/roles/atmo-vnc/tasks/guacamole.yml
@@ -28,4 +28,4 @@
 
 - name: guac - Start VNC Server for Guacamole
   command: >
-    /bin/su {{ ATMOUSERNAME }} -c "/usr/bin/vncserver -config /home/{{ ATMOUSERNAME }}/.vnc/config.guac :5"
+    /bin/su {{ ATMOUSERNAME }} -c "{{ VNC_EXECUTABLE }} -config /home/{{ ATMOUSERNAME }}/.vnc/config.guac :5"

--- a/ansible/roles/atmo-vnc/tasks/realvnc.yml
+++ b/ansible/roles/atmo-vnc/tasks/realvnc.yml
@@ -12,8 +12,6 @@
     state: absent
   with_items:
     - tightvncserver
-    # - tigervnc
-    # - tigervnc-server
 
 - name: create needed directories
   file:

--- a/ansible/roles/atmo-vnc/tasks/realvnc.yml
+++ b/ansible/roles/atmo-vnc/tasks/realvnc.yml
@@ -12,6 +12,7 @@
     state: absent
   with_items:
     - tightvncserver
+    - tigervnc-server
 
 - name: create needed directories
   file:
@@ -68,6 +69,12 @@
     state: present
     update_cache: yes
   when: ansible_distribution == "Ubuntu"
+
+- name: Link RealVNC binary to vncserver binary
+  file:
+    src: "/usr/bin/vncserver-virtual"
+    dest: "/usr/bin/vncserver"
+    state: link
 
 - name: remove locks and un-needed files
   file:

--- a/ansible/roles/atmo-vnc/tasks/realvnc.yml
+++ b/ansible/roles/atmo-vnc/tasks/realvnc.yml
@@ -93,7 +93,7 @@
 
 - name: kill all running vncserver sessions
   shell: >
-    /bin/su '{{ ATMOUSERNAME }}' -c "/usr/bin/vncserver -kill :'{{ item }}'"
+    /bin/su '{{ ATMOUSERNAME }}' -c "{{ VNC_EXECUTABLE }} -kill :'{{ item }}'"
   with_items: [1, 2, 3, 4, 5, 6, 7, 8]
   failed_when: False
 

--- a/ansible/roles/atmo-vnc/tasks/realvnc.yml
+++ b/ansible/roles/atmo-vnc/tasks/realvnc.yml
@@ -6,6 +6,15 @@
     - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
     - "{{ ansible_distribution }}.yml"
 
+- name: Remove old vnc packages
+  package:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - tightvncserver
+    # - tigervnc
+    # - tigervnc-server
+
 - name: create needed directories
   file:
     path: '{{ item.PATH }}'


### PR DESCRIPTION
Some images have `vncserver` software already installed. This caused deploy_error because the tasks intended to work with RealVNC do not work with other VNC servers.

This PR changes the `vncserver` executable from `/usr/bin/vncserver` to `/usr/bin/vncserver-virtual` so RealVNC is used even if `/usr/bin/vncserver` is linked to a different VNC server.

Tested on:
- [x] [RNAseq Alignment and Counting](https://atmo.cyverse.org/application/images/1407) (the image that brought this to our attention)
- [x] CentOS 6.8
- [x] Ubuntu 14.04