### PR TITLE
 Add roles and playbooks to add or remove users

### DIFF
--- a/ansible/playbooks/user_customizations/add_user.yml
+++ b/ansible/playbooks/user_customizations/add_user.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Add a user to the instance
+  hosts: atmosphere
+  roles:
+    - { role: add-user, when: USERSSHKEYS is defined and ATMOUSERNAME is defined }

--- a/ansible/playbooks/user_customizations/remove_user.yml
+++ b/ansible/playbooks/user_customizations/remove_user.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Remove a user from the instance
+  hosts: atmosphere
+  roles:
+    - { role: remove-user, when: USERSSHKEYS is defined and ATMOUSERNAME is defined }

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -12,3 +12,9 @@
 
 - src: CyVerse-Ansible.ez
   name: ez
+
+- src: CyVerse-Ansible.add-user
+  name: add-user
+
+- src: CyVerse-Ansible.remove-user
+  name: remove-user

--- a/ansible/roles/add-user/.travis.yml
+++ b/ansible/roles/add-user/.travis.yml
@@ -1,0 +1,42 @@
+---
+language: python
+python: "2.7"
+
+sudo: required
+dist: trusty
+services:
+  - docker
+
+env:
+  - distro: centos7
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distro: centos6
+    init: /sbin/init
+    run_opts: ""
+  - distro: ubuntu1604
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distro: ubuntu1404
+    init: /sbin/init
+    run_opts: ""
+
+before_install:
+  - 'docker pull geerlingguy/docker-${distro}-ansible:latest'
+
+script:
+  # Create a random file to store the container ID.
+  - container_id=$(mktemp)
+
+  - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/share-instance-ansible:ro ${run_opts} geerlingguy/docker-${distro}-ansible:latest "${init}" > "${container_id}"'
+
+  # Check the role/playbook's syntax.
+  - >
+    docker exec --tty "$(cat ${container_id})" env TERM=xterm
+    ansible-playbook /etc/ansible/roles/share-instance-ansible/tests/test.yml
+    --syntax-check
+
+  # Run the role/playbook with ansible-playbook.
+  - >
+    docker exec --tty "$(cat ${container_id})" env TERM=xterm
+    ansible-playbook /etc/ansible/roles/share-instance-ansible/tests/test.yml

--- a/ansible/roles/add-user/LICENSE.txt
+++ b/ansible/roles/add-user/LICENSE.txt
@@ -1,0 +1,13 @@
+Copyright (c) 2010-2016, The Arizona Board of Regents on behalf of The University of Arizona
+
+All rights reserved.
+
+Developed by: iPlant Collaborative as a collaboration between participants at BIO5 at The University of Arizona (the primary hosting institution), Cold Spring Harbor Laboratory, The University of Texas at Austin, and individual contributors. Find out more at http://www.iplantcollaborative.org/.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ * Neither the name of the iPlant Collaborative, BIO5, The University of Arizona, Cold Spring Harbor Laboratory, The University of Texas at Austin, nor the names of other contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ansible/roles/add-user/README.md
+++ b/ansible/roles/add-user/README.md
@@ -1,0 +1,10 @@
+# ansible-add-user
+
+### Role Variables
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+| Variable                | Required | Default | Choices                   | Comments                                   |
+|-------------------------|----------|---------|---------------------------|--------------------------------------------|
+| ATMOUSERNAME            | yes      |         |                           | username to add to instance                |
+| USERSSHKEYS             | yes      |         |                           | SSH keys to add                            |

--- a/ansible/roles/add-user/defaults/main.yml
+++ b/ansible/roles/add-user/defaults/main.yml
@@ -1,0 +1,29 @@
+---
+
+SUDOERS_USERS_AND_GROUPS:
+  TO_ADD:
+    users:
+      line: "%users ALL=(ALL) ALL"
+      reg: "^%users\\s+ALL=\\(ALL\\)\\s*ALL"
+    atmouser:
+      line: "{{ ATMOUSERNAME }} ALL=(ALL) ALL"
+      reg: "^{{ ATMOUSERNAME }}\\s+ALL=\\(ALL\\)\\s*ALL"
+  TO_REMOVE:
+    users:
+      line: "%users ALL=(ALL) NOPASSWD:ALL"
+      reg: "^%users\\s*ALL=\\(ALL\\)\\s*NOPASSWD:ALL"
+    atmouser_dupe:
+      line: "{{ ATMOUSERNAME }} ALL=(ALL) ALL"
+      reg: "^{{ ATMOUSERNAME }}\\s+ALL=\\(ALL\\)\\s*ALL"
+    atmouser_nopass:
+      line: "{{ ATMOUSERNAME }} ALL=(ALL) NOPASSWD:ALL"
+      reg: "^{{ ATMOUSERNAME }}\\s+ALL=\\(ALL\\)\\s*NOPASSWD:ALL"
+
+SETUP_USER_BASHRC_LINES: []
+
+ADD_TO_GROUP:
+  GROUP: users
+  LIST_OF_USERS:
+    - '{{ ATMOUSERNAME }}'
+
+MAKE_SUDO: False

--- a/ansible/roles/add-user/meta/.galaxy_install_info
+++ b/ansible/roles/add-user/meta/.galaxy_install_info
@@ -1,0 +1,1 @@
+{install_date: 'Mon Jul 24 21:37:45 2017', version: master}

--- a/ansible/roles/add-user/meta/main.yml
+++ b/ansible/roles/add-user/meta/main.yml
@@ -1,0 +1,20 @@
+---
+galaxy_info:
+  author: Calvin Mclean
+  description: Adds a user and keys to instance
+  company: CyVerse
+  license: BSD
+  min_ansible_version: 2.2
+  platforms:
+  - name: EL
+    versions:
+    - 6
+    - 7
+  - name: Ubuntu
+    versions:
+    - trusty
+    - xenial
+  galaxy_tags:
+    - cyverse
+
+dependencies: []

--- a/ansible/roles/add-user/tasks/main.yml
+++ b/ansible/roles/add-user/tasks/main.yml
@@ -1,0 +1,153 @@
+---
+
+- name: Fail if ATMOUSERNAME or USERSSHKEYS is undefined
+  fail:
+    msg: "ATMOUSERNAME or USERSSHKEYS is undefined but required for this role."
+  when: ATMOUSERNAME is not defined or USERSSHKEYS is not defined
+
+- name: 'local user account created'
+  user:
+    name: '{{ ATMOUSERNAME }}'
+    state: 'present'
+    shell: '/bin/bash'
+
+- name: 'home directory created for user'
+  file:
+    path: '/home/{{ ATMOUSERNAME }}'
+    state: 'directory'
+    mode: 0700
+
+- name: 'Add users ssh keys to authorized_keys'
+  authorized_key:
+    user: root
+    state: present
+    key: "{{ item }}"
+  with_items: '{{ USERSSHKEYS }}'
+  become: yes
+  when: USERSSHKEYS is defined
+
+- name: 'verify that home directory of user exists (to avoid ansible error)'
+  stat:
+    path: "/home/{{ ATMOUSERNAME }}"
+  register: user_home_dir
+  when: ATMOUSERNAME is defined
+
+- name: 'Add users ssh keys to authorized_keys to home directory of user'
+  authorized_key:
+    user: "{{ ATMOUSERNAME }}"
+    state: present
+    exclusive: no
+    key: '{{ item }}'
+  with_items: '{{ USERSSHKEYS }}'
+  when: ATMOUSERNAME is defined and USERSSHKEYS is defined and user_home_dir.stat.exists
+
+# From atmosphere-ansible role atmo-setup-user
+- name: 'conflicting users and groups removed from sudoers'
+  lineinfile:
+    dest: '/etc/sudoers'
+    backup: 'yes'
+    regexp: '{{ item.value.reg }}'
+    line: '{{ item.value.line }}'
+    state: 'absent'
+  with_dict: '{{ SUDOERS_USERS_AND_GROUPS.TO_REMOVE }}'
+  tags: 'sudoers'
+
+- name: 'all instances of atmosphere username removed from sudoers'
+  lineinfile:
+    dest: '/etc/sudoers'
+    state: 'absent'
+    regexp: '^{{ ATMOUSERNAME }}'
+  failed_when: false
+
+- name: 'users and groups added to sudoers'
+  lineinfile:
+    dest: '/etc/sudoers'
+    backup: true
+    regexp: '{{ item.value.reg }}'
+    line: '{{ item.value.line }}'
+    state: 'present'
+  with_dict: "{{ SUDOERS_USERS_AND_GROUPS.TO_ADD }}"
+  when: MAKE_SUDO == true
+  tags: 'sudoers'
+
+- name: '/etc/skel/.bashrc populated'
+  lineinfile:
+    dest: '/etc/skel/.bashrc'
+    line: '{{ item }}'
+  with_items: '{{ SETUP_USER_BASHRC_LINES }}'
+
+- name: 'atmousername and %users added to sudoers'
+  lineinfile:
+    dest: '/etc/sudoers'
+    backup: 'yes'
+    line: '{{ item }}'
+  with_items:
+    - '%users ALL=(ALL) NOPASSWD: ALL'
+    - '{{ ATMOUSERNAME }} ALL=(ALL) NOPASSWD:ALL'
+  # We want password-required sudo when we have an LDAP password to authenticate with
+  when: '(SETUP_LDAP is not defined or SETUP_LDAP != true) and MAKE_SUDO == true'
+
+- name: see if user is already located in /etc/group
+  command: grep "{{ ADD_TO_GROUP.GROUP }}:x:100:.*{{ ATMOUSERNAME }}.*" /etc/group
+  register: user_not_present
+  failed_when: False
+  tags: debug-ssh
+  when: ADD_TO_GROUP is defined
+
+- name: add ADD_TO_GROUP.GROUP to /etc/group if not present
+  lineinfile:
+    dest: "/etc/group"
+    regexp: '^({{ ADD_TO_GROUP.GROUP }}:x:100:)(.*)'
+    line: '\1{{ item }},\2'
+    state: present
+    backrefs: yes
+  with_items:
+    - '{{ ADD_TO_GROUP.LIST_OF_USERS }}'
+  tags: debug-ssh
+  when: ADD_TO_GROUP is defined and 'user_not_present.rc == 1'
+
+- name: add ATMOUSERNAME to users group
+  lineinfile:
+    dest: "/etc/group"
+    regexp: '^(users:x:100:)(.*)'
+    line: '\1{{ ATMOUSERNAME }},\2'
+    state: present
+    backrefs: yes
+  when:
+    - 'ADD_TO_GROUP is not defined'
+  tags: debug-ssh
+
+- name: see if user is already located in docker group
+  command: grep docker /etc/group
+  register: docker_user_present
+  failed_when: False
+
+- name: add user to docker group in /etc/group if docker group exists
+  lineinfile:
+    dest: "/etc/group"
+    regexp: '^(docker:x:999:)(.*)'
+    line: '\1{{ ATMOUSERNAME }},\2'
+    state: present
+    backrefs: yes
+  when: docker_user_present.rc == 0
+
+- name: check if the home directory exists yet
+  stat:
+    path: "/home/{{ ATMOUSERNAME }}"
+  register: atmouser_home
+
+- name: copy skel files into home directory
+  shell: cp -R /etc/skel /home/"{{ ATMOUSERNAME }}"
+  when: not atmouser_home.stat.exists
+
+# This chown will cause errors if /home/ATMOUSERNAME/.gvfs is mounted.  We should add code to manually unmount it if
+# it exists, then chown that user's home. -mgd
+- name: set ownership for user's home
+  file:
+    path: "/home/{{ ATMOUSERNAME }}"
+    owner: "{{ ATMOUSERNAME }}"
+    group: iplant-everyone
+    mode: 0755
+    recurse: yes
+  failed_when: False
+  tags: chown_users_home

--- a/ansible/roles/add-user/tests/inventory
+++ b/ansible/roles/add-user/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/ansible/roles/add-user/tests/test.yml
+++ b/ansible/roles/add-user/tests/test.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Playbook to add user
+  hosts: localhost
+  remote_user: root
+  vars:
+    ATMOUSERNAME: "hotdog"
+    USERSSHKEYS:
+      - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDttkkpIF9N10HloHoLxFX7+1U1zpqUwlK+62G/ZR2/jd+ILCkPP3JOb9d896Nmo80+llUkNSlon9B3hCY7htw3he5yKTO//0TIOGmC9SNDyDi2LR9s3kFQomJzVfzGbpEC0QbOQJSO9pvnL6msTiZ5XduGNSjvkIgU6WtWst2Pqm3xPJMmUoRdQ2Xyxya5vggHDCL+yJqR67UfOlovPG0N/O45d78+5peRb0tc5lqzd1zhvevlhKUgT1OW0B4a78TqazjuiUs38bO71OLWp7fE9fmRNtdKKTguHfHX91xxYCRW9GtKvvckZH1dBjwknQsoRuby3yJl2E6Lsu/F6e03 hotdog@travis"
+  roles:
+    - share-instance-ansible

--- a/ansible/roles/remove-user/CyVerse-Ansible.remove-user/LICENSE.txt
+++ b/ansible/roles/remove-user/CyVerse-Ansible.remove-user/LICENSE.txt
@@ -1,0 +1,13 @@
+Copyright (c) 2010-2016, The Arizona Board of Regents on behalf of The University of Arizona
+
+All rights reserved.
+
+Developed by: iPlant Collaborative as a collaboration between participants at BIO5 at The University of Arizona (the primary hosting institution), Cold Spring Harbor Laboratory, The University of Texas at Austin, and individual contributors. Find out more at http://www.iplantcollaborative.org/.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ * Neither the name of the iPlant Collaborative, BIO5, The University of Arizona, Cold Spring Harbor Laboratory, The University of Texas at Austin, nor the names of other contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ansible/roles/remove-user/CyVerse-Ansible.remove-user/README.md
+++ b/ansible/roles/remove-user/CyVerse-Ansible.remove-user/README.md
@@ -1,0 +1,10 @@
+# ansible-remove-user
+
+### Role Variables
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+| Variable                | Required | Default | Choices                   | Comments                                   |
+|-------------------------|----------|---------|---------------------------|--------------------------------------------|
+| ATMOUSERNAME            | yes      |         |                           | username to remove to instance                |
+| USERSSHKEYS             | yes      |         |                           | SSH keys to remove                            |

--- a/ansible/roles/remove-user/CyVerse-Ansible.remove-user/defaults/main.yml
+++ b/ansible/roles/remove-user/CyVerse-Ansible.remove-user/defaults/main.yml
@@ -1,0 +1,29 @@
+---
+
+SUDOERS_USERS_AND_GROUPS:
+  TO_ADD:
+    users:
+      line: "%users ALL=(ALL) ALL"
+      reg: "^%users\\s+ALL=\\(ALL\\)\\s*ALL"
+    atmouser:
+      line: "{{ ATMOUSERNAME }} ALL=(ALL) ALL"
+      reg: "^{{ ATMOUSERNAME }}\\s+ALL=\\(ALL\\)\\s*ALL"
+  TO_REMOVE:
+    users:
+      line: "%users ALL=(ALL) NOPASSWD:ALL"
+      reg: "^%users\\s*ALL=\\(ALL\\)\\s*NOPASSWD:ALL"
+    atmouser_dupe:
+      line: "{{ ATMOUSERNAME }} ALL=(ALL) ALL"
+      reg: "^{{ ATMOUSERNAME }}\\s+ALL=\\(ALL\\)\\s*ALL"
+    atmouser_nopass:
+      line: "{{ ATMOUSERNAME }} ALL=(ALL) NOPASSWD:ALL"
+      reg: "^{{ ATMOUSERNAME }}\\s+ALL=\\(ALL\\)\\s*NOPASSWD:ALL"
+
+SETUP_USER_BASHRC_LINES: []
+
+ADD_TO_GROUP:
+  GROUP: users
+  LIST_OF_USERS:
+    - '{{ ATMOUSERNAME }}'
+
+MAKE_SUDO: False

--- a/ansible/roles/remove-user/CyVerse-Ansible.remove-user/meta/.galaxy_install_info
+++ b/ansible/roles/remove-user/CyVerse-Ansible.remove-user/meta/.galaxy_install_info
@@ -1,0 +1,1 @@
+{install_date: 'Wed Jul 26 22:48:21 2017', version: master}

--- a/ansible/roles/remove-user/CyVerse-Ansible.remove-user/meta/main.yml
+++ b/ansible/roles/remove-user/CyVerse-Ansible.remove-user/meta/main.yml
@@ -1,0 +1,20 @@
+---
+galaxy_info:
+  author: Calvin Mclean
+  description: Removes a user and keys from instance
+  company: CyVerse
+  license: BSD
+  min_ansible_version: 2.2
+  platforms:
+  - name: EL
+    versions:
+    - 6
+    - 7
+  - name: Ubuntu
+    versions:
+    - trusty
+    - xenial
+  galaxy_tags:
+    - cyverse
+
+dependencies: []

--- a/ansible/roles/remove-user/CyVerse-Ansible.remove-user/tasks/main.yml
+++ b/ansible/roles/remove-user/CyVerse-Ansible.remove-user/tasks/main.yml
@@ -1,0 +1,97 @@
+---
+
+- name: Fail if ATMOUSERNAME or USERSSHKEYS is undefined
+  fail:
+    msg: "ATMOUSERNAME or USERSSHKEYS is undefined but required for this role."
+  when: ATMOUSERNAME is not defined or USERSSHKEYS is not defined
+
+- name: 'Remove user account'
+  user:
+    name: '{{ ATMOUSERNAME }}'
+    state: 'absent'
+    shell: '/bin/bash'
+    remove: 'yes'
+  failed_when: False
+
+- name: 'Remove user home directory'
+  file:
+    path: '/home/{{ ATMOUSERNAME }}'
+    state: 'absent'
+
+- name: 'Remove users ssh keys from root authorized_keys'
+  authorized_key:
+    user: root
+    state: absent
+    key: "{{ item }}"
+  with_items: '{{ USERSSHKEYS }}'
+  become: yes
+  when: USERSSHKEYS is defined
+
+# From atmosphere-ansible role atmo-setup-user
+- name: 'conflicting users and groups removed from sudoers'
+  lineinfile:
+    dest: '/etc/sudoers'
+    backup: 'yes'
+    regexp: '{{ item.value.reg }}'
+    line: '{{ item.value.line }}'
+    state: 'absent'
+  with_dict: '{{ SUDOERS_USERS_AND_GROUPS.TO_REMOVE }}'
+  tags: 'sudoers'
+
+- name: 'all instances of atmosphere username removed from sudoers'
+  lineinfile:
+    dest: '/etc/sudoers'
+    state: 'absent'
+    regexp: '^{{ ATMOUSERNAME }}'
+  failed_when: false
+
+- name: '/etc/skel/.bashrc un-populated'
+  lineinfile:
+    dest: '/etc/skel/.bashrc'
+    line: '{{ item }}'
+    state: 'absent'
+  with_items: '{{ SETUP_USER_BASHRC_LINES }}'
+
+- name: see if user is already located in /etc/group
+  command: grep "{{ ADD_TO_GROUP.GROUP }}:x:100:.*{{ ATMOUSERNAME }}.*" /etc/group
+  register: user_not_present
+  failed_when: False
+  tags: debug-ssh
+  when: ADD_TO_GROUP is defined
+
+- name: Remove ADD_TO_GROUP.GROUP to /etc/group if present
+  lineinfile:
+    dest: "/etc/group"
+    regexp: '^({{ ADD_TO_GROUP.GROUP }}:x:100:)(.*)'
+    line: '\1{{ item }},\2'
+    state: absent
+    backrefs: yes
+  with_items:
+    - '{{ ADD_TO_GROUP.LIST_OF_USERS }}'
+  tags: debug-ssh
+  when: ADD_TO_GROUP is defined and 'user_not_present.rc != 1'
+
+- name: Remove ATMOUSERNAME to users group
+  lineinfile:
+    dest: "/etc/group"
+    regexp: '^(users:x:100:)(.*)'
+    line: '\1{{ ATMOUSERNAME }},\2'
+    state: absent
+    backrefs: yes
+  when:
+    - 'ADD_TO_GROUP is not defined'
+  tags: debug-ssh
+
+- name: see if user is already located in docker group
+  command: grep docker /etc/group
+  register: docker_user_present
+  failed_when: False
+
+- name: Remove user from docker group in /etc/group if docker group doesnt exist
+  lineinfile:
+    dest: "/etc/group"
+    regexp: '^(docker:x:999:)(.*)'
+    line: '\1{{ ATMOUSERNAME }},\2'
+    state: absent
+    backrefs: yes
+  when: docker_user_present.rc != 0

--- a/ansible/roles/remove-user/README.md
+++ b/ansible/roles/remove-user/README.md
@@ -1,0 +1,10 @@
+# ansible-remove-user
+
+### Role Variables
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+| Variable                | Required | Default | Choices                   | Comments                                   |
+|-------------------------|----------|---------|---------------------------|--------------------------------------------|
+| ATMOUSERNAME            | yes      |         |                           | username to remove to instance                |
+| USERSSHKEYS             | yes      |         |                           | SSH keys to remove                            |

--- a/ansible/roles/remove-user/defaults/main.yml
+++ b/ansible/roles/remove-user/defaults/main.yml
@@ -1,0 +1,29 @@
+---
+
+SUDOERS_USERS_AND_GROUPS:
+  TO_ADD:
+    users:
+      line: "%users ALL=(ALL) ALL"
+      reg: "^%users\\s+ALL=\\(ALL\\)\\s*ALL"
+    atmouser:
+      line: "{{ ATMOUSERNAME }} ALL=(ALL) ALL"
+      reg: "^{{ ATMOUSERNAME }}\\s+ALL=\\(ALL\\)\\s*ALL"
+  TO_REMOVE:
+    users:
+      line: "%users ALL=(ALL) NOPASSWD:ALL"
+      reg: "^%users\\s*ALL=\\(ALL\\)\\s*NOPASSWD:ALL"
+    atmouser_dupe:
+      line: "{{ ATMOUSERNAME }} ALL=(ALL) ALL"
+      reg: "^{{ ATMOUSERNAME }}\\s+ALL=\\(ALL\\)\\s*ALL"
+    atmouser_nopass:
+      line: "{{ ATMOUSERNAME }} ALL=(ALL) NOPASSWD:ALL"
+      reg: "^{{ ATMOUSERNAME }}\\s+ALL=\\(ALL\\)\\s*NOPASSWD:ALL"
+
+SETUP_USER_BASHRC_LINES: []
+
+ADD_TO_GROUP:
+  GROUP: users
+  LIST_OF_USERS:
+    - '{{ ATMOUSERNAME }}'
+
+MAKE_SUDO: False

--- a/ansible/roles/remove-user/meta/.galaxy_install_info
+++ b/ansible/roles/remove-user/meta/.galaxy_install_info
@@ -1,0 +1,1 @@
+{install_date: 'Mon Jul 24 21:37:48 2017', version: master}

--- a/ansible/roles/remove-user/meta/main.yml
+++ b/ansible/roles/remove-user/meta/main.yml
@@ -1,0 +1,20 @@
+---
+galaxy_info:
+  author: Calvin Mclean
+  description: Removes a user and keys from instance
+  company: CyVerse
+  license: BSD
+  min_ansible_version: 2.2
+  platforms:
+  - name: EL
+    versions:
+    - 6
+    - 7
+  - name: Ubuntu
+    versions:
+    - trusty
+    - xenial
+  galaxy_tags:
+    - cyverse
+
+dependencies: []

--- a/ansible/roles/remove-user/tasks/main.yml
+++ b/ansible/roles/remove-user/tasks/main.yml
@@ -1,0 +1,96 @@
+---
+
+- name: Fail if ATMOUSERNAME or USERSSHKEYS is undefined
+  fail:
+    msg: "ATMOUSERNAME or USERSSHKEYS is undefined but required for this role."
+  when: ATMOUSERNAME is not defined or USERSSHKEYS is not defined
+
+- name: 'Remove user account'
+  user:
+    name: '{{ ATMOUSERNAME }}'
+    state: 'absent'
+    shell: '/bin/bash'
+    remove: 'yes'
+
+- name: 'Remove user home directory'
+  file:
+    path: '/home/{{ ATMOUSERNAME }}'
+    state: 'absent'
+
+- name: 'Remove users ssh keys from root authorized_keys'
+  authorized_key:
+    user: root
+    state: absent
+    key: "{{ item }}"
+  with_items: '{{ USERSSHKEYS }}'
+  become: yes
+  when: USERSSHKEYS is defined
+
+# From atmosphere-ansible role atmo-setup-user
+- name: 'conflicting users and groups removed from sudoers'
+  lineinfile:
+    dest: '/etc/sudoers'
+    backup: 'yes'
+    regexp: '{{ item.value.reg }}'
+    line: '{{ item.value.line }}'
+    state: 'absent'
+  with_dict: '{{ SUDOERS_USERS_AND_GROUPS.TO_REMOVE }}'
+  tags: 'sudoers'
+
+- name: 'all instances of atmosphere username removed from sudoers'
+  lineinfile:
+    dest: '/etc/sudoers'
+    state: 'absent'
+    regexp: '^{{ ATMOUSERNAME }}'
+  failed_when: false
+
+- name: '/etc/skel/.bashrc un-populated'
+  lineinfile:
+    dest: '/etc/skel/.bashrc'
+    line: '{{ item }}'
+    state: 'absent'
+  with_items: '{{ SETUP_USER_BASHRC_LINES }}'
+
+- name: see if user is already located in /etc/group
+  command: grep "{{ ADD_TO_GROUP.GROUP }}:x:100:.*{{ ATMOUSERNAME }}.*" /etc/group
+  register: user_not_present
+  failed_when: False
+  tags: debug-ssh
+  when: ADD_TO_GROUP is defined
+
+- name: Remove ADD_TO_GROUP.GROUP to /etc/group if present
+  lineinfile:
+    dest: "/etc/group"
+    regexp: '^({{ ADD_TO_GROUP.GROUP }}:x:100:)(.*)'
+    line: '\1{{ item }},\2'
+    state: absent
+    backrefs: yes
+  with_items:
+    - '{{ ADD_TO_GROUP.LIST_OF_USERS }}'
+  tags: debug-ssh
+  when: ADD_TO_GROUP is defined and 'user_not_present.rc != 1'
+
+- name: Remove ATMOUSERNAME to users group
+  lineinfile:
+    dest: "/etc/group"
+    regexp: '^(users:x:100:)(.*)'
+    line: '\1{{ ATMOUSERNAME }},\2'
+    state: absent
+    backrefs: yes
+  when:
+    - 'ADD_TO_GROUP is not defined'
+  tags: debug-ssh
+
+- name: see if user is already located in docker group
+  command: grep docker /etc/group
+  register: docker_user_present
+  failed_when: False
+
+- name: Remove user from docker group in /etc/group if docker group doesnt exist
+  lineinfile:
+    dest: "/etc/group"
+    regexp: '^(docker:x:999:)(.*)'
+    line: '\1{{ ATMOUSERNAME }},\2'
+    state: absent
+    backrefs: yes
+  when: docker_user_present.rc != 0


### PR DESCRIPTION
Adds two roles to add or remove users from an instance. Both roles require the variables "ATMOUSERNAME" and "USERSSHKEYS" to be defined.

Example usage:
`ansible-playbook playbooks/user_customization/add-user -e "ATMOUSERNAME=calvinmclean, USERSSHKEYS=<ssh pubkey>"`
`ansible-playbook playbooks/user_customization/remove-user -e "ATMOUSERNAME=calvinmclean, USERSSHKEYS=<ssh pubkey>"`