### PR TITLE
Skip filesystems mounted in home directory when using "chown" or "chmod"

### DIFF
--- a/ansible/roles/add-user/meta/.galaxy_install_info
+++ b/ansible/roles/add-user/meta/.galaxy_install_info
@@ -1,1 +1,1 @@
-{install_date: 'Mon Jul 24 21:37:45 2017', version: master}
+{install_date: 'Tue Aug 29 18:21:05 2017', version: master}

--- a/ansible/roles/add-user/tasks/main.yml
+++ b/ansible/roles/add-user/tasks/main.yml
@@ -140,14 +140,12 @@
   shell: cp -R /etc/skel /home/"{{ ATMOUSERNAME }}"
   when: not atmouser_home.stat.exists
 
-# This chown will cause errors if /home/ATMOUSERNAME/.gvfs is mounted.  We should add code to manually unmount it if
-# it exists, then chown that user's home. -mgd
-- name: set ownership for user's home
-  file:
-    path: "/home/{{ ATMOUSERNAME }}"
-    owner: "{{ ATMOUSERNAME }}"
-    group: iplant-everyone
-    mode: 0755
-    recurse: yes
+- name: Set ownership for user's home, ignoring mounted volumes
+  shell: >
+    find /home/{{ ATMOUSERNAME }} -mount | xargs chown {{ ATMOUSERNAME }}:iplant-everyone
   failed_when: False
-  tags: chown_users_home
+
+- name: Set permissions for user's home, ignoring mounted volumes
+  shell: >
+    find /home/{{ ATMOUSERNAME }} -mount | xargs chmod 755 {{ ATMOUSERNAME }}:iplant-everyone
+  failed_when: False

--- a/ansible/roles/atmo-setup-user/tasks/main.yml
+++ b/ansible/roles/atmo-setup-user/tasks/main.yml
@@ -88,9 +88,14 @@
   shell: cp -R /etc/skel /home/"{{ ATMOUSERNAME }}"
   when: not atmouser_home.stat.exists
 
-# This chown will cause errors if /home/ATMOUSERNAME/.gvfs is mounted.  We should add code to manually unmount it if
-# it exists, then chown that user's home. -mgd
-- name: set ownership for user's home
-  file: path="/home/{{ ATMOUSERNAME }}" owner="{{ ATMOUSERNAME }}" group=iplant-everyone mode=0755 recurse=yes
-  failed_when: False
+- block:
+    - name: Set ownership for user's home, ignoring mounted volumes
+      shell: >
+        find /home/{{ ATMOUSERNAME }} -mount | xargs chown {{ ATMOUSERNAME }}:iplant-everyone
+      failed_when: False
+
+    - name: Set permissions for user's home, ignoring mounted volumes
+      shell: >
+        find /home/{{ ATMOUSERNAME }} -mount | xargs chmod 755 {{ ATMOUSERNAME }}:iplant-everyone
+      failed_when: False
   tags: chown_users_home


### PR DESCRIPTION
Fixes Issue #99 by using Ansible facts to loop through mounts and check if any are in the user's home directory. If a volume is mounted in a home directory, a fact is set so it can be unmounted and remounted after `chown`-ing home directory.

### TODO:
- [x] Test test test