### PR TITLE
Set hostname in /etc/hostname and /etc/hosts

### DIFF
--- a/ansible/roles/atmo-dhcp/templates/hostname-exit-hook.sh.j2
+++ b/ansible/roles/atmo-dhcp/templates/hostname-exit-hook.sh.j2
@@ -98,5 +98,7 @@ if [ -z $hostname_value ]; then
     echo $(date +"%m%d%y %H:%M:%S") " Hostname could not be determined. using `hostname`" >> $LOG
 else
     hostname $hostname_value
+    echo $hostname_value > /etc/hostname
+    sed -i "/^127.0.0.1/ s/^.*$/127.0.0.1 $hostname_value localhost/" /etc/hosts
     echo $(date +"%m%d%y %H:%M:%S") "   Hostname has been set to `hostname`" >> $LOG
 fi


### PR DESCRIPTION
Part of fix for [this Galaxy issue](https://biostar.usegalaxy.org/p/24350/#24666) on Jetstream cloud. We should set the hostname in `/etc/hostname` and `/etc/hosts`.