### PR TITLE
Modifications to /etc/hosts at Andy E's suggestion

### DIFF
--- a/ansible/roles/atmo-dhcp/templates/hostname-exit-hook.sh.j2
+++ b/ansible/roles/atmo-dhcp/templates/hostname-exit-hook.sh.j2
@@ -101,7 +101,7 @@ else
     echo $hostname_value > /etc/hostname
     hostname_value_short=$(echo $hostname_value | sed "s/\..*//")
     myip=$(dig $hostname_value +short)
-    sed -i "s/^vm\d+-\d+\.cyverse\.org.*$//" /etc/hosts
+    sed -ri "s/^.*vm\d+-\d+\.cyverse\.org.*$//g" /etc/hosts
     echo "$myip $hostname_value $hostname_value_short" >> /etc/hosts
     echo $(date +"%m%d%y %H:%M:%S") "   Hostname has been set to `hostname`" >> $LOG
 fi

--- a/ansible/roles/atmo-dhcp/templates/hostname-exit-hook.sh.j2
+++ b/ansible/roles/atmo-dhcp/templates/hostname-exit-hook.sh.j2
@@ -101,7 +101,7 @@ else
     echo $hostname_value > /etc/hostname
     hostname_value_short=$(echo $hostname_value | sed "s/\..*//")
     myip=$(dig $hostname_value +short)
-    sed -ri "s/^.*vm\d+-\d+\.cyverse\.org.*$//g" /etc/hosts
+    sed -ri "/^.*vm[0-9]+-[0-9]+\.cyverse\.org.*$/d" /etc/hosts
     echo "$myip $hostname_value $hostname_value_short" >> /etc/hosts
     echo $(date +"%m%d%y %H:%M:%S") "   Hostname has been set to `hostname`" >> $LOG
 fi

--- a/ansible/roles/atmo-dhcp/templates/hostname-exit-hook.sh.j2
+++ b/ansible/roles/atmo-dhcp/templates/hostname-exit-hook.sh.j2
@@ -99,6 +99,9 @@ if [ -z $hostname_value ]; then
 else
     hostname $hostname_value
     echo $hostname_value > /etc/hostname
-    sed -i "/^127.0.0.1/ s/^.*$/127.0.0.1 $hostname_value localhost/" /etc/hosts
+    hostname_value_short=$(echo $hostname_value | sed "s/\..*//")
+    myip=$(dig $hostname_value +short)
+    sed -i "s/^vm\d+-\d+\.cyverse\.org.*$//" /etc/hosts
+    echo "$myip $hostname_value $hostname_value_short" >> /etc/hosts
     echo $(date +"%m%d%y %H:%M:%S") "   Hostname has been set to `hostname`" >> $LOG
 fi


### PR DESCRIPTION
Follow-up on #101, setting `/etc/hosts` to include the external IP address. Test results after deploying from atmobeta follow.

On an "Ubuntu 16.04 Non-GUI Base":
```
root@vm142-35:~# hostname
vm142-35.cyverse.org
root@vm142-35:~# hostname -s
vm142-35
root@vm142-35:~# uname -n
vm142-35.cyverse.org
root@vm142-35:~# cat /etc/hostname
vm142-35.cyverse.org
root@vm142-35:~# cat /etc/hosts
127.0.0.1 localhost

# The following lines are desirable for IPv6 capable hosts
::1 ip6-localhost ip6-loopback
fe00::0 ip6-localnet
ff00::0 ip6-mcastprefix
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters
ff02::3 ip6-allhosts
128.196.142.35 vm142-35.cyverse.org vm142-35
```

On an "Ubuntu 14.04.3 NoGUI Base":
```
root@vm142-72:~# hostname
vm142-72.cyverse.org
root@vm142-72:~# hostname -s
vm142-72
root@vm142-72:~# uname -n
vm142-72.cyverse.org
root@vm142-72:~# cat /etc/hostname
vm142-72.cyverse.org
root@vm142-72:~# cat /etc/hosts
127.0.0.1 localhost

# The following lines are desirable for IPv6 capable hosts
::1 ip6-localhost ip6-loopback
fe00::0 ip6-localnet
ff00::0 ip6-mcastprefix
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters
ff02::3 ip6-allhosts
128.196.142.72 vm142-72.cyverse.org vm142-72
```

On "CyVerse CentOS 6.8 GUI Base":
```
-bash-4.1# hostname
vm142-62.cyverse.org
-bash-4.1# hostname -s
vm142-62
-bash-4.1# uname -n
vm142-62.cyverse.org
-bash-4.1# cat /etc/hostname
vm142-62.cyverse.org
-bash-4.1# cat /etc/hosts
127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
128.196.142.62 vm142-62.cyverse.org vm142-62
```

Confirmed that suspend/resume results in a successful return to "Active" status (with new IP address and hostname in all the above places) for Ubuntu 16.04 and Ubuntu 14.04. (CentOS 6.8 still has the resume-from-suspend issue we're looking into.)