### PR TITLE
Improve the boot scripts experience

### DIFF
--- a/ansible/roles/atmo-user-boot-scripts/defaults/main.yml
+++ b/ansible/roles/atmo-user-boot-scripts/defaults/main.yml
@@ -1,15 +1,14 @@
+INSTANCE_SCRIPT_DIR: /etc/atmo/instance-scripts.d
+INSTANCE_SCRIPT_LOG_DIR: /var/log/atmo/instance-scripts
 POST_SCRIPT_DIR: /etc/atmo/post-scripts.d
 POST_SCRIPT_LOG_DIR: /var/log/atmo/post-scripts
-POST_SCRIPT_LOG_STDOUT: "{{ POST_SCRIPT_LOG_DIR }}/stdout" 
-POST_SCRIPT_LOG_STDERR: "{{ POST_SCRIPT_LOG_DIR }}/stderr"
 
-POST_MAKE_DIR: 
+POST_MAKE_DIRS:
   - "{{ POST_SCRIPT_DIR }}"
+  - "{{ INSTANCE_SCRIPT_DIR }}"
   - "{{ POST_SCRIPT_LOG_DIR }}"
+  - "{{ INSTANCE_SCRIPT_LOG_DIR }}"
 
-
-POST_SCRIPT_LOGS: 
-  - "{{ POST_SCRIPT_LOG_STDOUT }}"
-  - "{{ POST_SCRIPT_LOG_STDERR }}"
-
-POST_SCRIPT_DIR_RUN: "/etc/atmo/post-scripts.d/*"
+RUN_SCRIPTS:
+  - { log: "{{ INSTANCE_SCRIPT_LOG_DIR }}", dir: "{{ INSTANCE_SCRIPT_DIR }}" }
+  - { log: "{{ POST_SCRIPT_LOG_DIR }}", dir: "{{ POST_SCRIPT_DIR }}" }

--- a/ansible/roles/atmo-user-boot-scripts/defaults/main.yml
+++ b/ansible/roles/atmo-user-boot-scripts/defaults/main.yml
@@ -9,6 +9,6 @@ POST_MAKE_DIRS:
   - "{{ POST_SCRIPT_LOG_DIR }}"
   - "{{ INSTANCE_SCRIPT_LOG_DIR }}"
 
-RUN_SCRIPTS:
+ASYNC_RUN_SCRIPTS:
   - { log: "{{ INSTANCE_SCRIPT_LOG_DIR }}", dir: "{{ INSTANCE_SCRIPT_DIR }}" }
   - { log: "{{ POST_SCRIPT_LOG_DIR }}", dir: "{{ POST_SCRIPT_DIR }}" }

--- a/ansible/roles/atmo-user-boot-scripts/tasks/main.yml
+++ b/ansible/roles/atmo-user-boot-scripts/tasks/main.yml
@@ -1,38 +1,43 @@
 - name: bootscript_1 - make directories for post scripts and logs
   file: path={{ item }} state=directory
-  with_items: '{{ POST_MAKE_DIR }}'
+  with_items: '{{ POST_MAKE_DIRS }}'
 
-- name: bootscript_2 - touch log files
-  file: path={{ item }} state=touch
-  with_items: '{{ POST_SCRIPT_LOGS }}'
-  # The following two lines work around https://github.com/ansible/ansible-modules-core/issues/170
-  register: touch_log
-  changed_when: touch_log.diff.before.state != "file"
-
-- name: bootscript_3 - run user's scripts in script directory
-  shell: >
-    for SCRIPT in {{ POST_SCRIPT_DIR_RUN }};
-    do
-        if [ -f $SCRIPT -a -x $SCRIPT ]
-        then
-            ATMO_USER={{ ATMOUSERNAME }} $SCRIPT 2>> {{ POST_SCRIPT_LOG_STDERR }} >> {{ POST_SCRIPT_LOG_STDOUT }}
-        fi
-    done
-
-- name: bootscript_4.1 - copy scripts to location
+- name: bootscript_2 - copy scripts to script directory
   copy:
     content: "{{ item.text }}"
-    dest: "{{POST_SCRIPT_DIR}}/{{item.name}}"
+    dest: "{{INSTANCE_SCRIPT_DIR}}/{{item.name}}"
     mode: "u+rwx"
   with_items: '{{ SCRIPTS }}'
 
-- name: bootscript_4.2 - run scripts passed in to the playbook
-  shell: >
-    ATMO_USER={{ ATMOUSERNAME }} "{{POST_SCRIPT_DIR}}/{{ item.name }}" 2>> {{ POST_SCRIPT_LOG_STDERR }} >> {{ POST_SCRIPT_LOG_STDOUT }}
-  with_items: '{{ SCRIPTS }}'
+#Reviewer NOTE:
+# - Can we refactor for-loop and log-name logic to ansible?
+- name: bootscript_3 - execute scripts found in RUN_SCRIPT_DIRS
+  shell: |
+    set -m  # allows backgrounded processes to persist
+    for SCRIPT in {{item.dir}}/*;
+    do
+      if [[ -f $SCRIPT && -x $SCRIPT ]]; then
+        LOG_DIR="{{item.log}}"
+        BASENAME=${SCRIPT##*/}
+        DATE=$(date +%F_%T)
+        SCRIPT_STDOUT=$LOG_DIR/$BASENAME.$DATE.stdout
+        SCRIPT_STDERR=$LOG_DIR/$BASENAME.$DATE.stderr
+        ATMO_USER={{ATMOUSERNAME}} nohup $SCRIPT >$SCRIPT_STDOUT 2>$SCRIPT_STDERR </dev/null &
+      fi
+    done
+    exit 0
+  args:
+    executable: /bin/bash
+  register: shell_result
+  with_items: '{{ RUN_SCRIPTS }}'
 
-- name: bootscript_4.3 - remove scripts
+# Helpful if the shell script above fails..
+# - debug: msg="item.item={{item.item}}, item.stdout={{item.stdout}}, item.changed={{item.changed}}"
+#   with_items: "{{shell_result.results}}"
+
+
+- name: bootscript_4 - Remove instance scripts to avoid being picked up on next run
   file:
-    path: "{{POST_SCRIPT_DIR}}/{{ item.name }}"
+    path: "{{INSTANCE_SCRIPT_DIR}}/{{ item.name }}"
     state: absent
   with_items: '{{ SCRIPTS }}'

--- a/ansible/roles/atmo-user-boot-scripts/tasks/main.yml
+++ b/ansible/roles/atmo-user-boot-scripts/tasks/main.yml
@@ -1,3 +1,9 @@
+- fail: msg="Variable DEPLOY_SCRIPTS is not set."
+  when: DEPLOY_SCRIPTS is not defined
+
+- fail: msg="Variable ASYNC_SCRIPTS is not set."
+  when: ASYNC_SCRIPTS is not defined
+
 - name: bootscript_1 - make directories for post scripts and logs
   file: path={{ item }} state=directory
   with_items: '{{ POST_MAKE_DIRS }}'
@@ -7,11 +13,33 @@
     content: "{{ item.text }}"
     dest: "{{INSTANCE_SCRIPT_DIR}}/{{item.name}}"
     mode: "u+rwx"
-  with_items: '{{ SCRIPTS }}'
+  with_items: '{{ DEPLOY_SCRIPTS }}'
 
-#Reviewer NOTE:
-# - Can we refactor for-loop and log-name logic to ansible?
-- name: bootscript_3 - execute scripts found in RUN_SCRIPT_DIRS
+- name: bootscript_3 - Run deploy boot scripts synchronously, register results and return if failure occurs.
+  command: "{{INSTANCE_SCRIPT_DIR}}/{{item.name}}"
+  register: "deploy_script_result"
+  with_items: '{{ DEPLOY_SCRIPTS }}'
+
+- name: bootscript_4 - Remove instance scripts to avoid being picked up on next run
+  file:
+    path: "{{INSTANCE_SCRIPT_DIR}}/{{ item.name }}"
+    state: absent
+  with_items: '{{ DEPLOY_SCRIPTS }}'
+
+
+- name: bootscript_5 - copy scripts to script directory
+  copy:
+    content: "{{ item.text }}"
+    dest: "{{INSTANCE_SCRIPT_DIR}}/{{item.name}}"
+    mode: "u+rwx"
+  with_items: '{{ ASYNC_SCRIPTS }}'
+
+#Future TODO:
+# - If possible, refactor these components into ansible:
+#   - get name of  each file in script directory
+#   - if file is executable, generate 'dynamic log files' based on 'script|basename' and 'date()'
+#   - if file is executable, run ` set -m; nohup-call-to-file..` and point to dynamic log files from above.
+- name: bootscript_6 - execute scripts found in RUN_SCRIPT_DIRS asynchronously
   shell: |
     set -m  # allows backgrounded processes to persist
     for SCRIPT in {{item.dir}}/*;
@@ -29,15 +57,15 @@
   args:
     executable: /bin/bash
   register: shell_result
-  with_items: '{{ RUN_SCRIPTS }}'
+  with_items: '{{ ASYNC_RUN_SCRIPTS }}'
 
 # Helpful if the shell script above fails..
 # - debug: msg="item.item={{item.item}}, item.stdout={{item.stdout}}, item.changed={{item.changed}}"
 #   with_items: "{{shell_result.results}}"
 
-
-- name: bootscript_4 - Remove instance scripts to avoid being picked up on next run
+- name: bootscript_7 - Remove instance scripts to avoid being picked up on next run
   file:
     path: "{{INSTANCE_SCRIPT_DIR}}/{{ item.name }}"
     state: absent
-  with_items: '{{ SCRIPTS }}'
+  with_items: '{{ ASYNC_SCRIPTS }}'
+


### PR DESCRIPTION
- Create a directory for 'post-scripts' (Baked into the image)
  and for 'instance-scripts' (added to the instance)
- Write a shell command that will be the 'script runner':
  - Creates dynamic log location for each script, including datetime for
  multiple runs.
  - 'Fire and forget' scripts to avoid 'hanging' scripts


Built in conjunction with https://github.com/cyverse/atmosphere/pull/506