### PR TITLE
WIP ATMO-1978: "check_web_desktop: True" when NOVNC is disabled

### DIFF
--- a/ansible/playbooks/utils/atmo_check_novnc.yml
+++ b/ansible/playbooks/utils/atmo_check_novnc.yml
@@ -1,5 +1,10 @@
 ---
 - name: Playbook to fail when VNC is not running
   hosts: atmosphere
+  pre_tasks:
+  - name: Fail when SETUP_NOVNC is false because the role will skip instead of fail
+    fail:
+      msg: "SETUP_NOVNC is false or undefined"
+    when: SETUP_NOVNC is not defined or SETUP_NOVNC == false
   roles:
     - { role: atmo-check-novnc, when: SETUP_NOVNC is defined and SETUP_NOVNC == true }


### PR DESCRIPTION
It looks like Atmosphere checks NOVNC by running a playbook and looking for failures. When `SETUP_NOVNC = false`, the playbook skips the role, so there are no failures. This PR adds a task to be executed before the roles, and will fail if `SETUP_NOVNC = FALSE`.

#### TODO:
- [ ] Needs to be tested
This has pretty specific testing circumstances so I haven't been able to test yet.