### PR TITLE
WIP ATMO-1979: Atmosphere-Ansible adds/changes VNC on VMs with X2Go

### DIFF
--- a/ansible/playbooks/instance_deploy/30_post_user_install.yml
+++ b/ansible/playbooks/instance_deploy/30_post_user_install.yml
@@ -2,11 +2,16 @@
 # Requires ATMOUSERNAME and VNCLICENSE
 - name: Playbook lists roles that should be executed after ATMOUSERNAME has been created
   hosts: atmosphere
+  pre_tasks:
+    - name: Determine if X2GO is installed
+      stat:
+        path: "/etc/x2go"
+      register: x2go
   roles:
     - { role: atmo-fail2ban, when: true }
     - { role: irods-icommands, when: SETUP_IRODS_ICOMMANDS is defined and SETUP_IRODS_ICOMMANDS == true }
     - { role: atmo-kanki-irodsclient, when: SETUP_IRODS_ICOMMANDS is defined and SETUP_IRODS_ICOMMANDS == true }
     - { role: install-browser, when: SETUP_GUI_BROWSER is defined and SETUP_GUI_BROWSER == true }
-    - { role: atmo-vnc, when: SETUP_REALVNC_SERVER is defined and SETUP_REALVNC_SERVER == true }
+    - { role: atmo-vnc, when: SETUP_REALVNC_SERVER is defined and SETUP_REALVNC_SERVER == true and x2go.stat.exists == false }
     - { role: atmo-backup, when: SETUP_ATMO_BACKUP is defined and SETUP_ATMO_BACKUP == true }
     - atmo-cleanup


### PR DESCRIPTION
Some images are designed to be used with X2Go for visualization, but ~~the `atmo-vnc` role wipes out that functionality~~ it prevents Atmosphere Web Desktops from working properly. This PR adds a pre_task to the playbook that executes the `atmo-vnc` role to make the role only run when `/etc/x2go` does **not** exist.

#### TODO:
- [ ] Needs some more testing. Works as a stand-alone playbook, but I have to test it in the atmosphere-ansible workflow.