### PR TITLE
Include short hostame in /etc/hosts

### DIFF
--- a/ansible/roles/atmo-dhcp/templates/hostname-exit-hook.sh.j2
+++ b/ansible/roles/atmo-dhcp/templates/hostname-exit-hook.sh.j2
@@ -98,7 +98,8 @@ if [ -z $hostname_value ]; then
     echo $(date +"%m%d%y %H:%M:%S") " Hostname could not be determined. using `hostname`" >> $LOG
 else
     hostname $hostname_value
+    short_hostname=$(hostname -s)
     echo $hostname_value > /etc/hostname
-    sed -i "/^127.0.0.1/ s/^.*$/127.0.0.1 $hostname_value localhost/" /etc/hosts
+    sed -i "/^127.0.0.1/ s/^.*$/127.0.0.1 $hostname_value $short_hostname localhost/" /etc/hosts
     echo $(date +"%m%d%y %H:%M:%S") "   Hostname has been set to `hostname`" >> $LOG
 fi


### PR DESCRIPTION
This complements #101 (and is needed when Slurm is being installed on the system, for example)