### PR TITLE
Restart networking for CentOS 6 on deploy

### DIFF
--- a/ansible/playbooks/instance_deploy/10_setup_pkg_mgr.yml
+++ b/ansible/playbooks/instance_deploy/10_setup_pkg_mgr.yml
@@ -3,6 +3,7 @@
   hosts: atmosphere
   roles:
     - atmo-pre-setup
+    - fix-centos6-networking
     - atmo-ntp
     - { role: atmo-dhcp, when: SETUP_DHCP_CLIENT is defined and SETUP_DHCP_CLIENT == true }
     - { role: ldap, when: SETUP_LDAP is defined and SETUP_LDAP == true }

--- a/ansible/roles/fix-centos6-networking/tasks/main.yml
+++ b/ansible/roles/fix-centos6-networking/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Networking service restarted for CentOS 6
+  service:
+    name: network
+    state: restarted
+  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '6'


### PR DESCRIPTION
Possible fix for CentOS 6 instances having broken networking after suspend+resume. Tried to test but atmobeta is not in a great state at the moment, will revisit.