### PR TITLE
Make sure /etc/hosts gets edited only once

### DIFF
--- a/ansible/roles/atmo-dhcp/templates/hostname-exit-hook.sh.j2
+++ b/ansible/roles/atmo-dhcp/templates/hostname-exit-hook.sh.j2
@@ -102,6 +102,6 @@ else
     hostname_value_short=$(echo $hostname_value | sed "s/\..*//")
     myip=$(dig $hostname_value +short)
     sed -ri "/^.*vm[0-9]+-[0-9]+\.cyverse\.org.*$/d" /etc/hosts
-    echo "$myip $hostname_value $hostname_value_short" >> /etc/hosts
+    grep -q "$myip $hostname_value $hostname_value_short" /etc/hosts || echo "$myip $hostname_value $hostname_value_short" >> /etc/hosts
     echo $(date +"%m%d%y %H:%M:%S") "   Hostname has been set to `hostname`" >> $LOG
 fi


### PR DESCRIPTION
This is an improvement to #102. Otherwise, it seems the script continues to run against the instance as long as the instance is alive and we end up with `/etc/hosts` looking like so:
```
cat /etc/hosts
127.0.0.1 localhost js-157-56

# The following lines are desirable for IPv6 capable hosts
::1 ip6-localhost ip6-loopback
fe00::0 ip6-localnet
ff00::0 ip6-mcastprefix
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters
ff02::3 ip6-allhosts
149.165.169.22 js-169-22.jetstream-cloud.org js-169-22
149.165.169.22 js-169-22.jetstream-cloud.org js-169-22
149.165.169.22 js-169-22.jetstream-cloud.org js-169-22
149.165.169.22 js-169-22.jetstream-cloud.org js-169-22
149.165.169.22 js-169-22.jetstream-cloud.org js-169-22
149.165.169.22 js-169-22.jetstream-cloud.org js-169-22
149.165.169.22 js-169-22.jetstream-cloud.org js-169-22
149.165.169.22 js-169-22.jetstream-cloud.org js-169-22
149.165.169.22 js-169-22.jetstream-cloud.org js-169-22
149.165.169.22 js-169-22.jetstream-cloud.org js-169-22
149.165.169.22 js-169-22.jetstream-cloud.org js-169-22
149.165.169.22 js-169-22.jetstream-cloud.org js-169-22
149.165.169.22 js-169-22.jetstream-cloud.org js-169-22
149.165.169.22 js-169-22.jetstream-cloud.org js-169-22
149.165.169.22 js-169-22.jetstream-cloud.org js-169-22
149.165.169.22 js-169-22.jetstream-cloud.org js-169-22
```