### PR TITLE
Don't start vncserver if its already running

### DIFF
--- a/ansible/roles/atmo-vnc/tasks/guacamole.yml
+++ b/ansible/roles/atmo-vnc/tasks/guacamole.yml
@@ -26,6 +26,13 @@
     src: 'config.guac.j2'
     dest: '/home/{{ ATMOUSERNAME }}/.vnc/config.guac'
 
+- name: Check if vnc is already running
+  command: lsof -i :5905
+  register: vnc_running
+  failed_when: False
+  changed_when: False
+
 - name: guac - Start VNC Server for Guacamole
   command: >
     /bin/su {{ ATMOUSERNAME }} -c "{{ VNC_EXECUTABLE }} -config /home/{{ ATMOUSERNAME }}/.vnc/config.guac :5"
+  when: vnc_running.rc != 0


### PR DESCRIPTION
Problem: deploy failure, vncserver can not be started if its already running
on a display
Solution: Use a command to test if vnc is already running. Then start it if
it's not running.