### PR TITLE
check-restart-network script

### DIFF
--- a/ansible/roles/fix-centos6-networking/tasks/main.yml
+++ b/ansible/roles/fix-centos6-networking/tasks/main.yml
@@ -1,7 +1,21 @@
 ---
 
+
 - name: Networking service restarted for CentOS 6
   service:
-    name: network
-    state: restarted
+    name: 'network'
+    state: 'restarted'
+  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '6'
+- name: check-restart-network script templated
+  template:
+    src: 'check-restart-network.sh.j2'
+    dest: '/etc/cron.d/check-restart-network.sh'
+    mode: '0700'
+    owner: 'root'
+  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '6'
+- name: check-restart-network script scheduled via cron
+  cron:
+    job: '/etc/cron.d/check-restart-network.sh'
+    minute: '*/5'
+    name: 'check-restart-network'
   when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '6'

--- a/ansible/roles/fix-centos6-networking/templates/check-restart-network.sh.j2
+++ b/ansible/roles/fix-centos6-networking/templates/check-restart-network.sh.j2
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# https://serverfault.com/questions/47915/how-do-i-get-the-default-gateway-in-linux-given-the-destination
+DEFAULT_GW=$(/sbin/ip route show default | awk '/default/ {print $3}')
+ping -c 1 -W 1 $DEFAULT_GW > /dev/null 2>&1
+pingrc=$?
+if [[ $pingrc != 0 ]]
+then
+    /sbin/service network restart
+fi


### PR DESCRIPTION
Apparently I was mistaken with #109, and more is needed to bring CentOS 6 instances back online after a suspend + resume. Let me test this one more time.