### PR TITLE
This pull request will fix a recent ansible-pull issue caused by an update to ansible-pull itself

### DIFF
--- a/ansible/roles/atmo-backup/files/cyverse_backup.sh
+++ b/ansible/roles/atmo-backup/files/cyverse_backup.sh
@@ -260,7 +260,7 @@ then
            read destination
            echo
 
-           FILE=`/bin/basename $source`
+           FILE=`basename $source`
            FILE_EXISTS="$destination/$FILE"
 
            output=`set_env`

--- a/ansible/roles/atmo-common/tasks/main.yml
+++ b/ansible/roles/atmo-common/tasks/main.yml
@@ -124,7 +124,7 @@
 # normally, dependency on a remote resource should be limited, but in this
 #   situation. we'll allow it due to the benefit. Any failure is ignore,
 #   limiting the risk of affecting deploys.
-- name: checkout the git repo
+- name: checkout the top level git repo for ez
   git: 
     repo: "https://github.com/cyverse/cyverse-ez.git"
     dest: "/opt/cyverse-ez" 

--- a/ansible/roles/atmo-common/tasks/main.yml
+++ b/ansible/roles/atmo-common/tasks/main.yml
@@ -118,6 +118,19 @@
     mode: 0755
   when: EZ_INSTALL_DIR is defined
 
+# This line is needed because ansible-pull broke as of 2.4.0.
+# Once ansible-pull is fixed to actually pull, we can remove this task
+# See https://github.com/ansible/ansible/issues/30636
+# normally, dependency on a remote resource should be limited, but in this
+#   situation. we'll allow it due to the benefit. Any failure is ignore,
+#   limiting the risk of affecting deploys.
+- name: checkout the git repo
+  git: 
+    repo: "https://github.com/cyverse/cyverse-ez.git"
+    dest: "/opt/cyverse-ez" 
+    force: yes
+  ignore_errors: yes
+
 # ansible-pull ez facility install without EZ_INSTALL_DIR; ignore errors
 - name: ansible-pull the ez facility
   shell: ansible-pull -v -U https://github.com/cyverse/cyverse-ez.git -d /opt/cyverse-ez -i locahost -f >> /var/log/cyverse-ez.log 2>&1


### PR DESCRIPTION
The change will use ansible git module to download the cyverse ez repo before ansible-pull. Tested. Any error in either the git download or ansible-pull will be nonbreaking to the deploy process.