### PR TITLE
Provide a default value for SETUP_GUACAMOLE

### DIFF
--- a/ansible/playbooks/instance_deploy/41_shell_access.yml
+++ b/ansible/playbooks/instance_deploy/41_shell_access.yml
@@ -34,4 +34,4 @@
     EXTERNAL_HOST: "guac_server"
     USERNAME: "{{ ATMOUSERNAME }}"
   roles:
-    - { role: "sshkey-host-access", when: SETUP_GUACAMOLE == true }
+    - { role: "sshkey-host-access", when: (SETUP_GUACAMOLE | default(false)) == true }


### PR DESCRIPTION
Problem: Missing variable results in instance deploy failure
Solution: Don't require variable to be defined in the secrets repo, provide a default.

When you deploy, if `SETUP_GUACAMOLE` is missing from the secrets repo group_vars file, atmosphere-ansible fails on instance deploy, because the variable is undefined. This variable was missing from jtc group_vars. Rather than require it to be added, just provide a default.