### PR TITLE
WIP - Use atmosphere variables over group_vars, match variable names

### DIFF
--- a/ansible/roles/add-user/defaults/main.yml
+++ b/ansible/roles/add-user/defaults/main.yml
@@ -1,23 +1,9 @@
 ---
 
-SUDOERS_USERS_AND_GROUPS:
-  TO_ADD:
-    users:
-      line: "%users ALL=(ALL) ALL"
-      reg: "^%users\\s+ALL=\\(ALL\\)\\s*ALL"
-    atmouser:
-      line: "{{ ATMOUSERNAME }} ALL=(ALL) ALL"
-      reg: "^{{ ATMOUSERNAME }}\\s+ALL=\\(ALL\\)\\s*ALL"
-  TO_REMOVE:
-    users:
-      line: "%users ALL=(ALL) NOPASSWD:ALL"
-      reg: "^%users\\s*ALL=\\(ALL\\)\\s*NOPASSWD:ALL"
-    atmouser_dupe:
-      line: "{{ ATMOUSERNAME }} ALL=(ALL) ALL"
-      reg: "^{{ ATMOUSERNAME }}\\s+ALL=\\(ALL\\)\\s*ALL"
-    atmouser_nopass:
-      line: "{{ ATMOUSERNAME }} ALL=(ALL) NOPASSWD:ALL"
-      reg: "^{{ ATMOUSERNAME }}\\s+ALL=\\(ALL\\)\\s*NOPASSWD:ALL"
+SUDOER_GROUPS:
+  - users
+SUDOER_USERS:
+  - {{ ATMOUSERNAME }}
 
 SETUP_USER_BASHRC_LINES: []
 

--- a/ansible/roles/add-user/tasks/main.yml
+++ b/ansible/roles/add-user/tasks/main.yml
@@ -46,29 +46,36 @@
   lineinfile:
     dest: '/etc/sudoers'
     backup: 'yes'
-    regexp: '{{ item.value.reg }}'
-    line: '{{ item.value.line }}'
-    state: 'absent'
-  with_dict: '{{ SUDOERS_USERS_AND_GROUPS.TO_REMOVE }}'
-  tags: 'sudoers'
-
-- name: 'all instances of atmosphere username removed from sudoers'
-  lineinfile:
-    dest: '/etc/sudoers'
-    state: 'absent'
-    regexp: '^{{ ATMOUSERNAME }}'
-  failed_when: false
-
-- name: 'users and groups added to sudoers'
-  lineinfile:
-    dest: '/etc/sudoers'
-    backup: true
-    regexp: '{{ item.value.reg }}'
-    line: '{{ item.value.line }}'
+    line: "%{{ item }} ALL=(ALL) ALL"
+    regex: "^%{{ item }}\\s+ALL=\\(ALL\\)\\s*ALL"
     state: 'present'
-  with_dict: "{{ SUDOERS_USERS_AND_GROUPS.TO_ADD }}"
-  when: MAKE_SUDO == true
-  tags: 'sudoers'
+  with_items: {{ SUDOER_GROUPS }}
+  tags:
+      - 'sudoers'
+      - fuckyou
+
+- name: 'conflicting users and groups removed from sudoers'
+  lineinfile:
+    dest: '/etc/sudoers'
+    backup: 'yes'
+    line: "{{ item }} ALL=(ALL) ALL"
+    regex: "^{{ item }}\\s+ALL=\\(ALL\\)\\s*ALL"
+    state: 'present'
+  with_items: {{ SUDOER_USERS }}
+  tags:
+      - 'sudoers'
+      - fuckyou
+
+# - name: 'users and groups added to sudoers'
+#   lineinfile:
+#     dest: '/etc/sudoers'
+#     backup: true
+#     regexp: '{{ item.value.reg }}'
+#     line: '{{ item.value.line }}'
+#     state: 'present'
+#   with_dict: "{{ SUDOERS_USERS_AND_GROUPS.TO_ADD }}"
+#   when: MAKE_SUDO == true
+#   tags: 'sudoers'
 
 - name: '/etc/skel/.bashrc populated'
   lineinfile:

--- a/ansible/roles/atmo-ssh-setup/defaults/main.yml
+++ b/ansible/roles/atmo-ssh-setup/defaults/main.yml
@@ -4,7 +4,12 @@ SSH_ALLOW_GROUPS: "root users"
 
 SSH_PORT: 22
 
-SSH_OPTIONS: -o PreferredAuthentications=publickey -o ConnectTimeout=2
+SSH_OPTIONS: >
+    -o PreferredAuthentications=publickey
+    -o ConnectTimeout=2
+    -o IdentityFile="{{ ATMOSPHERE_PRIVATE_KEYFILE }}"
+    -o StrictHostKeyChecking=no
+    -o UserKnownHostsFile=/dev/null
 
 SSHD_CHANGES:
   - regexp: '^PermitRootLogin'

--- a/ansible/roles/atmo-ssh-setup/tasks/root-setup.yml
+++ b/ansible/roles/atmo-ssh-setup/tasks/root-setup.yml
@@ -8,20 +8,10 @@
   lineinfile:
     dest: /root/.ssh/authorized_keys
     state: absent
-    regexp: command\=
+    regexp: 'command='
 
-- name: Add ssh keys to authorized_keys
+- name: Give atmosphere ssh access into guest
   authorized_key:
     user: root
-    key: "{{ item }}"
+    key: "{{ lookup('file', ATMOSPHERE_KEYPAIR_FILE) }}"
     state: present
-  with_items: '{{ SSHKEYS }}'
-  when: SSHKEYS is defined
-
-- name: Remove ssh keys from authorized_keys
-  authorized_key:
-    user: root
-    key: "{{ item }}"
-    state: absent
-  with_items: '{{ SSH_KEYS_TO_REMOVE }}'
-  when: SSH_KEYS_TO_REMOVE is defined


### PR DESCRIPTION
Problem: Variables are duplicated in group_vars and in atmosphere and have
different names
Solution: Use atmosphere naming, requires atmo to pass new vars to supspace

This makes the SSHKEYS and SSHKEYS_TO_REMOVE no longer necessary. Requires
atmosphere to call subspace with ATMOSPHERE_KEYPAIR_FILE and
ATMOSPHERE_PRIVATE_KEYFILE, which are defined in atmosphere.settings;

~~Depends on  https://github.com/cyverse/atmosphere/pull/523~~

Depends on `<pending clank pr>`