### PR TITLE
WIP ATMO-1969: Modify conditionals in atmo-ssh-setup to avoid 'undefined' errors.

### DIFF
--- a/ansible/roles/atmo-ssh-setup/tasks/main.yml
+++ b/ansible/roles/atmo-ssh-setup/tasks/main.yml
@@ -17,29 +17,36 @@
       command ssh {{ SSH_OPTIONS }} -p {{ ansible_port }} centos@{{ vm_ip }} echo "Atmosphere is cool!"
     register: centos_connection
     failed_when: false
-    when: "'Atmosphere is cool!' not in root_connection.stdout"
+    when: "(root_connection is defined) and (root_connection.stdout is defined) and
+           ('Atmosphere is cool!' not in root_connection.stdout)"
 
   - name: Test Ubuntu connection and register ubuntu_connection
     local_action: >
       command ssh {{ SSH_OPTIONS }} -p {{ ansible_port }} ubuntu@{{ vm_ip }} echo "Atmosphere is cool!"
     register: ubuntu_connection
     failed_when: false
-    when: "('Atmosphere is cool!' not in root_connection.stdout) and ('Atmoshphere is cool!' not in centos_connection.stdout)"
+    when: "(root_connection is defined) and (root_connection.stdout is defined) and
+           ('Atmosphere is cool!' not in root_connection.stdout) and
+           (centos_connection is defined) and (centos_connection.stdout is defined) and
+           ('Atmoshphere is cool!' not in centos_connection.stdout)"
   ignore_errors: True
 
 # Set use_remote_user depending on which SSH task succeeded
 - block:
   - name: Set use_remote_user variable to "centos"
     set_fact: use_remote_user=centos
-    when: "(not centos_connection|skipped) and ('Atmosphere is cool!' in centos_connection.stdout)"
+    when: "(centos_connection is defined) and (centos_connection.stdout is defined) and (not centos_connection|skipped) and
+           ('Atmosphere is cool!' in centos_connection.stdout)"
 
   - name: Set use_remote_user variable to "ubuntu"
     set_fact: use_remote_user=ubuntu
-    when: "(not ubuntu_connection|skipped) and ('Atmosphere is cool!' in ubuntu_connection.stdout)"
+    when: "(ubuntu_connection is defined) and (ubuntu_connection.stdout is defined) and (not ubuntu_connection|skipped) and
+           ('Atmosphere is cool!' in ubuntu_connection.stdout)"
 
   - name: Set use_remote_user variable to "root"
     set_fact: use_remote_user=root
-    when: "'Atmosphere is cool!' in root_connection.stdout"
+    when: "(root_connection is defined) and (root_connection.stdout is defined) and
+           ('Atmosphere is cool!' in root_connection.stdout)"
 
 - name: Fail if use_remote_user cannot be found
   fail:


### PR DESCRIPTION
This PR addresses a failure that would occur when variables like `root_connection` are defined, but `root_connection.stdout` is not. This is the error: `Make sure your variable name does not contain invalid characters like '-': argument of type 'StrictUndefined' is not iterable`. This error is not clear, but after some online research and trying different variable combinations, I confirmed that it is caused by the undefined `root_connection.stdout`.

In order to check if `root_connection.stdout` is undefined, we should first check if `root_connection` is undefined, because if it is, then `root_connection.stdout is defined` will fail.

The JIRA ticket says that atmosphere-ansible fails after N number of deployments, but I was unable to re-create this error because of the unknown N. However, I confirmed that instances still deploy with these modified conditionals.