### PR TITLE
Problem: atmosphere-ansible reliance on ssh_config can make it hard to debug...

### DIFF
--- a/ansible/roles/atmo-ssh-setup/defaults/main.yml
+++ b/ansible/roles/atmo-ssh-setup/defaults/main.yml
@@ -4,7 +4,12 @@ SSH_ALLOW_GROUPS: "root users"
 
 SSH_PORT: 22
 
-SSH_OPTIONS: -o PreferredAuthentications=publickey -o ConnectTimeout=2
+SSH_OPTIONS: >
+    -o PreferredAuthentications=publickey
+    -o ConnectTimeout=2
+    -o IdentityFile="/opt/dev/atmosphere/extras/ssh/id_rsa"
+    -o StrictHostKeyChecking=no
+    -o UserKnownHostsFile=/dev/null
 
 SSHD_CHANGES:
   - regexp: '^PermitRootLogin'


### PR DESCRIPTION
... sometimes different SSH keys are used, etc.

Solution: Update SSH Options to avoid reliance on ssh config


**WIP: This needs to become configurable before merging, because not all paths will match this.**

