### PR TITLE
Problem: atmosphere-ansible ssh setup tasks can be hard to debug

### DIFF
--- a/ansible/roles/atmo-ssh-setup/defaults/main.yml
+++ b/ansible/roles/atmo-ssh-setup/defaults/main.yml
@@ -2,12 +2,14 @@
 
 SSH_ALLOW_GROUPS: "root users"
 
+SSH_IDENTITY_FILE: "/opt/dev/atmosphere/extras/ssh/id_rsa"
+
 SSH_PORT: 22
 
 SSH_OPTIONS: >
     -o PreferredAuthentications=publickey
     -o ConnectTimeout=2
-    -o IdentityFile="/opt/dev/atmosphere/extras/ssh/id_rsa"
+    -o IdentityFile={{ SSH_IDENTITY_FILE }}
     -o StrictHostKeyChecking=no
     -o UserKnownHostsFile=/dev/null
 

--- a/ansible/roles/atmo-ssh-setup/defaults/main.yml
+++ b/ansible/roles/atmo-ssh-setup/defaults/main.yml
@@ -4,7 +4,12 @@ SSH_ALLOW_GROUPS: "root users"
 
 SSH_PORT: 22
 
-SSH_OPTIONS: -o PreferredAuthentications=publickey -o ConnectTimeout=2
+SSH_OPTIONS: >
+    -o PreferredAuthentications=publickey
+    -o ConnectTimeout=2
+    -o IdentityFile="/opt/dev/atmosphere/extras/ssh/id_rsa"
+    -o StrictHostKeyChecking=no
+    -o UserKnownHostsFile=/dev/null
 
 SSHD_CHANGES:
   - regexp: '^PermitRootLogin'

--- a/ansible/roles/atmo-ssh-setup/tasks/main.yml
+++ b/ansible/roles/atmo-ssh-setup/tasks/main.yml
@@ -2,7 +2,8 @@
 
 # We need to set this fact because on the following local_actions, ansible_host is localhost
 - name: Get VM IP address
-  set_fact: vm_ip="{{ ansible_host }}"
+  set_fact:
+    vm_ip: "{{ ansible_host }}"
 
 # SSH as different users to determine which can connect (and determine linux distro)
 - block:

--- a/ansible/roles/check_networking/defaults/main.yml
+++ b/ansible/roles/check_networking/defaults/main.yml
@@ -1,5 +1,14 @@
 ---
 
+SSH_IDENTITY_FILE: "/opt/dev/atmosphere/extras/ssh/id_rsa"
+
+SSH_OPTIONS: >
+    -o PreferredAuthentications=publickey
+    -o ConnectTimeout=2
+    -o IdentityFile={{ SSH_IDENTITY_FILE }}
+    -o StrictHostKeyChecking=no
+    -o UserKnownHostsFile=/dev/null
+
 SSH_PORT: 22
 SSH_PORT_TIMEOUT: 30
 SSH_TIMEOUT: 30

--- a/ansible/roles/check_networking/tasks/main.yml
+++ b/ansible/roles/check_networking/tasks/main.yml
@@ -1,8 +1,10 @@
 --- 
 - name: get atmo vm ip address
-  set_fact: vm_ip="{{ ansible_host }}"
+  set_fact:
+    vm_ip: "{{ ansible_host }}"
 
-- debug: msg="Atmo VM IP is {{ vm_ip }}"
+- debug:
+    msg: "Atmo VM IP is {{ vm_ip }}"
 
 - name: verify that host is reachable via ssh port
   local_action: wait_for
@@ -14,7 +16,8 @@
   tags: verify-ssh
 
 - name: test default ansible connection
-  local_action: "shell ssh -p {{ ansible_port }} root@{{ vm_ip }} 'echo hello' | grep 'hello'"
+  local_action: >
+      command ssh {{ SSH_OPTIONS }} -p {{ ansible_port }} root@{{ vm_ip }} 'echo hello' | grep 'hello'
   register: default_remote_user
   ignore_errors: yes
   failed_when: False
@@ -25,7 +28,8 @@
 # CENTOS SETUP
 ###
 - name: test centos connection
-  local_action: "shell ssh -p {{ ansible_port }} centos@{{ vm_ip }} 'echo hello' | grep 'hello'"
+  local_action: >
+      command ssh {{ SSH_OPTIONS}} -p {{ ansible_port }} centos@{{ vm_ip }} 'echo hello' | grep 'hello'
   register: centos_remote_user
   ignore_errors: yes
   when: default_remote_user|failed
@@ -37,7 +41,8 @@
 # UBUNTU SETUP
 ###
 - name: test ubuntu connection
-  local_action: "shell ssh -p {{ ansible_port }} ubuntu@{{ vm_ip }} 'echo hello' | grep 'hello'"
+  local_action: >
+    command ssh {{ SSH_OPTIONS }} -p {{ ansible_port }} ubuntu@{{ vm_ip }} 'echo hello' | grep 'hello'
   register: ubuntu_remote_user
   ignore_errors: yes
   when: default_remote_user|failed and centos_remote_user|failed


### PR DESCRIPTION
Solution: 
- Pass in all expected SSH args as options.
- Allow `atmosphere` to set the `SSH_IDENTITY_FILE` in extra_vars.