### PR TITLE
atmo-ssh-setup initial connection loop

### DIFF
--- a/ansible/roles/atmo-ssh-setup/defaults/main.yml
+++ b/ansible/roles/atmo-ssh-setup/defaults/main.yml
@@ -42,3 +42,8 @@ SSHD_CHANGES:
   - regexp: 'AllowUsers'
     line: ''
     state: 'absent'
+
+CONNECTION_USERNAMES:
+  - 'root'
+  - 'centos'
+  - 'ubuntu'

--- a/ansible/roles/atmo-ssh-setup/tasks/find_connection.yml
+++ b/ansible/roles/atmo-ssh-setup/tasks/find_connection.yml
@@ -1,0 +1,15 @@
+---
+
+- set_fact: username="{{ item }}"
+
+- block:
+  - name: Test connection to instance using different usernames
+    local_action: >
+      command ssh {{ SSH_OPTIONS }} -p {{ ansible_port }} {{ username }}@{{ vm_ip }} echo "Atmosphere is cool!"
+    failed_when: false
+    register: connection
+
+  - name: Set use_remote_user based on connection results
+    set_fact: use_remote_user="{{ username }}"
+    when: '"Atmosphere is cool!" in connection.stdout'
+  when: use_remote_user is undefined

--- a/ansible/roles/atmo-ssh-setup/tasks/find_connection.yml
+++ b/ansible/roles/atmo-ssh-setup/tasks/find_connection.yml
@@ -1,15 +1,14 @@
 ---
-
-- set_fact: username="{{ item }}"
+# Design note: These tasks are included from main.yml because it allows us to use 'with_items' on more than one task.
 
 - block:
   - name: Test connection to instance using different usernames
     local_action: >
-      command ssh {{ SSH_OPTIONS }} -p {{ ansible_port }} {{ username }}@{{ vm_ip }} echo "Atmosphere is cool!"
+      command ssh {{ SSH_OPTIONS }} -p {{ ansible_port }} {{ item }}@{{ vm_ip }} echo "Atmosphere is cool!"
     failed_when: false
     register: connection
 
   - name: Set use_remote_user based on connection results
-    set_fact: use_remote_user="{{ username }}"
+    set_fact: use_remote_user="{{ item }}"
     when: '"Atmosphere is cool!" in connection.stdout'
   when: use_remote_user is undefined

--- a/ansible/roles/atmo-ssh-setup/tasks/find_connection.yml
+++ b/ansible/roles/atmo-ssh-setup/tasks/find_connection.yml
@@ -1,14 +1,17 @@
 ---
 # Design note: These tasks are included from main.yml because it allows us to use 'with_items' on more than one task.
 
+- set_fact:
+    outer_item: "{{ item }}"
+
 - block:
   - name: Test connection to instance using different usernames
     local_action: >
-      command ssh {{ SSH_OPTIONS }} -p {{ ansible_port }} {{ item }}@{{ vm_ip }} echo "Atmosphere is cool!"
+      command ssh {{ SSH_OPTIONS }} -p {{ ansible_port }} {{ outer_item }}@{{ vm_ip }} echo "Atmosphere is cool!"
     failed_when: false
     register: connection
 
   - name: Set use_remote_user based on connection results
-    set_fact: use_remote_user="{{ item }}"
+    set_fact: use_remote_user="{{ outer_item }}"
     when: '"Atmosphere is cool!" in connection.stdout'
   when: use_remote_user is undefined

--- a/ansible/roles/atmo-ssh-setup/tasks/main.yml
+++ b/ansible/roles/atmo-ssh-setup/tasks/main.yml
@@ -6,41 +6,8 @@
     vm_ip: "{{ ansible_host }}"
 
 # SSH as different users to determine which can connect (and determine linux distro)
-- block:
-  - name: Test default ansible connection and register root_connection
-    local_action: >
-      command ssh {{ SSH_OPTIONS }} -p {{ ansible_port }} root@{{ vm_ip }} echo "Atmosphere is cool!"
-    failed_when: false
-    register: root_connection
-
-  - name: Test CentOS connection and register centos_connection
-    local_action: >
-      command ssh {{ SSH_OPTIONS }} -p {{ ansible_port }} centos@{{ vm_ip }} echo "Atmosphere is cool!"
-    register: centos_connection
-    failed_when: false
-    when: "'Atmosphere is cool!' not in root_connection.stdout"
-
-  - name: Test Ubuntu connection and register ubuntu_connection
-    local_action: >
-      command ssh {{ SSH_OPTIONS }} -p {{ ansible_port }} ubuntu@{{ vm_ip }} echo "Atmosphere is cool!"
-    register: ubuntu_connection
-    failed_when: false
-    when: "('Atmosphere is cool!' not in root_connection.stdout) and ('Atmoshphere is cool!' not in centos_connection.stdout)"
-  ignore_errors: True
-
-# Set use_remote_user depending on which SSH task succeeded
-- block:
-  - name: Set use_remote_user variable to "centos"
-    set_fact: use_remote_user=centos
-    when: "(not centos_connection|skipped) and ('Atmosphere is cool!' in centos_connection.stdout)"
-
-  - name: Set use_remote_user variable to "ubuntu"
-    set_fact: use_remote_user=ubuntu
-    when: "(not ubuntu_connection|skipped) and ('Atmosphere is cool!' in ubuntu_connection.stdout)"
-
-  - name: Set use_remote_user variable to "root"
-    set_fact: use_remote_user=root
-    when: "'Atmosphere is cool!' in root_connection.stdout"
+- include_tasks: 'find_connection.yml'
+  with_items: "{{ CONNECTION_USERNAMES }}"
 
 - name: Fail if use_remote_user cannot be found
   fail:

--- a/ansible/roles/atmo-ssh-setup/tasks/main.yml
+++ b/ansible/roles/atmo-ssh-setup/tasks/main.yml
@@ -5,7 +5,7 @@
   set_fact:
     vm_ip: "{{ ansible_host }}"
 
-- include_tasks: 'find_connection.yml'
+- include: 'find_connection.yml'
   with_items: "{{ CONNECTION_USERNAMES }}"
 
 - name: Fail if use_remote_user cannot be found

--- a/ansible/roles/atmo-ssh-setup/tasks/main.yml
+++ b/ansible/roles/atmo-ssh-setup/tasks/main.yml
@@ -5,7 +5,6 @@
   set_fact:
     vm_ip: "{{ ansible_host }}"
 
-# SSH as different users to determine which can connect (and determine linux distro)
 - include_tasks: 'find_connection.yml'
   with_items: "{{ CONNECTION_USERNAMES }}"
 


### PR DESCRIPTION
This allows `atmosphere-ansible` to be more scalable since usernames can simply be added to a list and will be used in the tasks. It requires use of the `include` module and an additional tasks file because it allows `with_items` to loop over multiple tasks. If one of the listed usernames is able to connect successfully, the rest will be skipped.

The `include` module is deprecated and will be completely removed in Ansible 2.8. Once we start using Ansible 2.4, we will be able to use `include_tasks` instead.

- Tested on Atmosphere test server deploying instances. **Note**: all connections succeeded with the `root` user, which is last in the list so it successfully loops past invalid usernames
- Tested manually against VMs with `ubuntu` or `centos` user
- Changed the order of the list to confirm that remaining list items are skipped after a successful connection.

Additional note:
```
- set_fact:
    outer_item: "{{ item }}"
```

This task is used in `find_connection.yml` so a future developer could implement a loop in the file without getting stumped by the inner loop `{{ item }}` overwriting the outer loop `{{ item }}`.