### PR TITLE
Set default font for XTerm to TrueType

### DIFF
--- a/ansible/roles/atmo-vnc/files/Xresources
+++ b/ansible/roles/atmo-vnc/files/Xresources
@@ -1,0 +1,3 @@
+xterm*faceName: Ubuntu Mono
+xterm*faceSize: 12
+xterm*renderFont: true

--- a/ansible/roles/atmo-vnc/tasks/main.yml
+++ b/ansible/roles/atmo-vnc/tasks/main.yml
@@ -65,4 +65,6 @@
 
   - include: novnc.yml
     when: SETUP_NOVNC is defined and SETUP_NOVNC == true
+
+  - include: xterm_font.yml
   when: has_gui

--- a/ansible/roles/atmo-vnc/tasks/xterm_font.yml
+++ b/ansible/roles/atmo-vnc/tasks/xterm_font.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Create .Xresources file for user
+  copy:
+    src: 'files/Xresources'
+    dest: '/home/{{ ATMOUSERNAME }}/.Xresources'
+
+- name: Update X server for all displays
+  become: true
+  become_user: '{{ ATMOUSERNAME }}'
+  command: >
+    /usr/bin/xrdb -display {{ item }} -merge /home/{{ ATMOUSERNAME }}/.Xresources
+  with_items:
+    - ':1'
+    - ':2'
+    - ':5'


### PR DESCRIPTION
Ubuntu 16 instances with XTerm default to a small, hard to read font. The problem is exaggerated when the display resolution is increased. This PR changes the default font size and enables rendering for TrueType fonts. Here is an image with terminals before and after changing the defaults (display resolution is 1920x1080):

![screen shot 2017-11-09 at 11 14 26 am](https://user-images.githubusercontent.com/19335917/32622162-41893670-c53f-11e7-97eb-a2c1906ed774.png)

Things I noticed during testing:
- CentOS and Ubuntu 14 instances are unaffected by the changes because the default terminal emulator is not XTerm. This is fine because the default terminal is good looking and has intuitive menus for customization if needed.
