### PR TITLE
Create desktop shortcut to change the display resolution

### DIFF
--- a/ansible/roles/atmo-vnc/files/change_resolution.desktop
+++ b/ansible/roles/atmo-vnc/files/change_resolution.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Version=1.0
+Name=change_desktop_resolution
+comment=Change desktop resolution
+Exec=/opt/cyverse_change_resolution.sh
+Terminal=true
+Type=Application
+Categories=Utility

--- a/ansible/roles/atmo-vnc/files/cyverse_change_resolution.sh
+++ b/ansible/roles/atmo-vnc/files/cyverse_change_resolution.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+xrandr -q | head -n -4
+
+read -p "Enter number or resolution:" res
+xrandr -s $res

--- a/ansible/roles/atmo-vnc/tasks/main.yml
+++ b/ansible/roles/atmo-vnc/tasks/main.yml
@@ -10,24 +10,20 @@
   with_first_found:
     - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
     - "{{ ansible_distribution }}.yml"
-  tags: test
 
 - name: Verify that X server exists
   stat:
     path: '{{ XGUI.xsession_path }}'
   register: xsession
-  tags: test
 
 - name: Verify that xterm session exists
   stat:
     path: '{{ XGUI.xterm_path }}'
   register: xterm
-  tags: test
 
 - name: Set flag for GUI systems
   set_fact:
     has_gui: '{{ xsession.stat.exists and xterm.stat.exists }}'
-  tags: test
 
 - block:
   - block:
@@ -66,14 +62,12 @@
       src: 'files/cyverse_change_resolution.sh'
       dest: '/opt/cyverse_change_resolution.sh'
       mode: '0755'
-    tags: test
 
   - name: Copy desktop icon for changing desktop resolution
     copy:
       src: 'files/change_resolution.desktop'
       dest: '/home/{{ ATMOUSERNAME }}/Desktop/change_resolution.desktop'
       mode: '0755'
-    tags: test
 
   - include: realvnc.yml
     when: SETUP_REALVNC_SERVER is defined and SETUP_REALVNC_SERVER == true

--- a/ansible/roles/atmo-vnc/tasks/main.yml
+++ b/ansible/roles/atmo-vnc/tasks/main.yml
@@ -10,20 +10,24 @@
   with_first_found:
     - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
     - "{{ ansible_distribution }}.yml"
+  tags: test
 
 - name: Verify that X server exists
   stat:
     path: '{{ XGUI.xsession_path }}'
   register: xsession
+  tags: test
 
 - name: Verify that xterm session exists
   stat:
     path: '{{ XGUI.xterm_path }}'
   register: xterm
+  tags: test
 
 - name: Set flag for GUI systems
   set_fact:
     has_gui: '{{ xsession.stat.exists and xterm.stat.exists }}'
+  tags: test
 
 - block:
   - block:
@@ -56,6 +60,20 @@
         when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= "16"
     ignore_errors: yes
     when: SET_DESKTOP_BACKGROUND is defined and SET_DESKTOP_BACKGROUND == true
+
+  - name: Copy script to change desktop resolution
+    copy:
+      src: 'files/cyverse_change_resolution.sh'
+      dest: '/opt/cyverse_change_resolution.sh'
+      mode: '0755'
+    tags: test
+
+  - name: Copy desktop icon for changing desktop resolution
+    copy:
+      src: 'files/change_resolution.desktop'
+      dest: '/home/{{ ATMOUSERNAME }}/Desktop/change_resolution.desktop'
+      mode: '0755'
+    tags: test
 
   - include: realvnc.yml
     when: SETUP_REALVNC_SERVER is defined and SETUP_REALVNC_SERVER == true


### PR DESCRIPTION
The default display resolution for VNC sessions is 1024x768, which does not give the user much room to work with. If users browse through the wiki they would be able to find the command to change the resolution, but I assume many don't know that is an option. This PR will allow users to easily choose from all the available resolution options.

![2017-11-09 11_28_28](https://user-images.githubusercontent.com/19335917/32623053-254ec418-c542-11e7-9000-e432b893fc10.gif)
