### PR TITLE
Ubuntu only: fixes false positive ban of users who successfully login too many times

### DIFF
--- a/ansible/roles/ldap/tasks/main.yml
+++ b/ansible/roles/ldap/tasks/main.yml
@@ -185,6 +185,13 @@
   tags:
     - common-session
 
+- name: template common-auth
+  template: src=Ubuntu.common-auth.j2 dest=/etc/pam.d/common-auth backup=yes
+  when: ansible_distribution == "Ubuntu"
+  tags:
+    - common-auth
+
+
 - name: template nsswitch.conf
   template: src=Ubuntu.nsswitch.conf.j2 dest=/etc/nsswitch.conf backup=yes
   when: ansible_distribution == "Ubuntu"

--- a/ansible/roles/ldap/templates/Ubuntu.common-auth.j2
+++ b/ansible/roles/ldap/templates/Ubuntu.common-auth.j2
@@ -1,0 +1,28 @@
+#
+# /etc/pam.d/common-auth - authentication settings common to all services
+#
+# This file is included from other service-specific PAM config files,
+# and should contain a list of the authentication modules that define
+# the central authentication scheme for use on the system
+# (e.g., /etc/shadow, LDAP, Kerberos, etc.).  The default is to use the
+# traditional Unix authentication mechanisms.
+#
+# As of pam 1.0.1-6, this file is managed by pam-auth-update by default.
+# To take advantage of this, it is recommended that you configure any
+# local modules either before or after the default block, and use
+# pam-auth-update to manage selection of other modules.  See
+# pam-auth-update(8) for details.
+
+# here are the per-package modules (the "Primary" block)
+#auth	[success=2 default=ignore]	pam_unix.so nullok_secure
+#auth	[success=1 default=ignore]	pam_ldap.so use_first_pass
+auth	[success=2 default=ignore]	pam_ldap.so
+auth	[success=1 default=ignore]	pam_unix.so nullok_secure use_first_pass
+# here's the fallback if no module succeeds
+auth	requisite			pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+auth	required			pam_permit.so
+# and here are more per-package modules (the "Additional" block)
+# end of pam-auth-update config


### PR DESCRIPTION
This pull request essentially changes the order of of pam auth to ldap first, then local auth second