### PR TITLE
Problem: instances fail to boot if a volume is removed outside of Atmosphere

### DIFF
--- a/ansible/roles/atmo-ephemeral-mount/defaults/main.yml
+++ b/ansible/roles/atmo-ephemeral-mount/defaults/main.yml
@@ -4,3 +4,4 @@ disk_mounted_elsewhere: false
 
 MOUNT_PATH: '/scratch'
 MOUNT_TYPE: 'ext4'
+MOUNT_OPTS: "nofail"

--- a/ansible/roles/atmo-ephemeral-mount/defaults/main.yml
+++ b/ansible/roles/atmo-ephemeral-mount/defaults/main.yml
@@ -4,4 +4,5 @@ disk_mounted_elsewhere: false
 
 MOUNT_PATH: '/scratch'
 MOUNT_TYPE: 'ext4'
-MOUNT_OPTS: "nofail"
+MOUNT_OPTS: 'default,nofail'
+MOUNT_PASSNO: '2'

--- a/ansible/roles/atmo-ephemeral-mount/defaults/main.yml
+++ b/ansible/roles/atmo-ephemeral-mount/defaults/main.yml
@@ -4,5 +4,5 @@ disk_mounted_elsewhere: false
 
 MOUNT_PATH: '/scratch'
 MOUNT_TYPE: 'ext4'
-MOUNT_OPTS: 'default,nofail'
+MOUNT_OPTS: 'defaults,nofail'
 MOUNT_PASSNO: '2'

--- a/ansible/roles/atmo-ephemeral-mount/tasks/main.yml
+++ b/ansible/roles/atmo-ephemeral-mount/tasks/main.yml
@@ -1,9 +1,10 @@
 ---
 
-- name: Set MOUNT_OPTS Ubuntu < 16
-  set_fact:
-    MOUNT_OPTS: 'defaults,nobootwait'
-  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version < "16"
+- name: Gather OS specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
+    - "{{ ansible_distribution }}.yml"
 
 - name: 'See if we have an ephemeral disk'
   stat:

--- a/ansible/roles/atmo-ephemeral-mount/tasks/main.yml
+++ b/ansible/roles/atmo-ephemeral-mount/tasks/main.yml
@@ -33,6 +33,8 @@
       src: '{{ ephem_stat.stat.lnk_source }}'
       fstype: '{{ MOUNT_TYPE }}'
       state: 'mounted'
+      opts: 'nobootwait'
+      passno: '2'
 
   - name: 'Data loss warning for Ephemeral storage'
     copy:

--- a/ansible/roles/atmo-ephemeral-mount/tasks/main.yml
+++ b/ansible/roles/atmo-ephemeral-mount/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Set MOUNT_OPTS Ubuntu < 16
   set_fact:
-    MOUNT_OPTS: 'nobootwait'
+    MOUNT_OPTS: 'default,nobootwait'
   when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version < "16"
 
 - name: 'See if we have an ephemeral disk'
@@ -39,7 +39,7 @@
       fstype: '{{ MOUNT_TYPE }}'
       state: 'mounted'
       opts: '{{ MOUNT_OPTS }}'
-      passno: '2'
+      passno: '{{ MOUNT_PASSNO }}'
 
   - name: 'Data loss warning for Ephemeral storage'
     copy:

--- a/ansible/roles/atmo-ephemeral-mount/tasks/main.yml
+++ b/ansible/roles/atmo-ephemeral-mount/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Set MOUNT_OPTS Ubuntu < 16
   set_fact:
-    MOUNT_OPTS: 'default,nobootwait'
+    MOUNT_OPTS: 'defaults,nobootwait'
   when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version < "16"
 
 - name: 'See if we have an ephemeral disk'

--- a/ansible/roles/atmo-ephemeral-mount/tasks/main.yml
+++ b/ansible/roles/atmo-ephemeral-mount/tasks/main.yml
@@ -3,8 +3,10 @@
 - name: Gather OS specific variables
   include_vars: "{{ item }}"
   with_first_found:
-    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
-    - "{{ ansible_distribution }}.yml"
+    - files:
+        - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
+        - "{{ ansible_distribution }}.yml"
+      skip: true
 
 - name: 'See if we have an ephemeral disk'
   stat:

--- a/ansible/roles/atmo-ephemeral-mount/tasks/main.yml
+++ b/ansible/roles/atmo-ephemeral-mount/tasks/main.yml
@@ -33,7 +33,7 @@
       src: '{{ ephem_stat.stat.lnk_source }}'
       fstype: '{{ MOUNT_TYPE }}'
       state: 'mounted'
-      opts: 'nobootwait'
+      opts: 'nofail'
       passno: '2'
 
   - name: 'Data loss warning for Ephemeral storage'

--- a/ansible/roles/atmo-ephemeral-mount/tasks/main.yml
+++ b/ansible/roles/atmo-ephemeral-mount/tasks/main.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: Set MOUNT_OPTS Ubuntu < 16
+  set_fact:
+    MOUNT_OPTS: 'nobootwait'
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version < "16"
+
 - name: 'See if we have an ephemeral disk'
   stat:
     path: '/dev/disk/by-label/ephemeral0'
@@ -33,7 +38,7 @@
       src: '{{ ephem_stat.stat.lnk_source }}'
       fstype: '{{ MOUNT_TYPE }}'
       state: 'mounted'
-      opts: 'nofail'
+      opts: '{{ MOUNT_OPTS }}'
       passno: '2'
 
   - name: 'Data loss warning for Ephemeral storage'

--- a/ansible/roles/atmo-ephemeral-mount/vars/Ubuntu-14.yml
+++ b/ansible/roles/atmo-ephemeral-mount/vars/Ubuntu-14.yml
@@ -1,0 +1,3 @@
+---
+
+MOUNT_OPTS: 'defaults,nobootwait'

--- a/ansible/roles/atmo-mount-volume/defaults/main.yml
+++ b/ansible/roles/atmo-mount-volume/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 
 ATMO_USER_GROUP: "users"
+MOUNT_OPTS: "nofail"

--- a/ansible/roles/atmo-mount-volume/tasks/main.yml
+++ b/ansible/roles/atmo-mount-volume/tasks/main.yml
@@ -1,9 +1,10 @@
 ---
 
-- name: Set VOLUME_OPTS Ubuntu < 16
-  set_fact:
-    VOLUME_OPTS: 'defaults,nobootwait'
-  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version < "16"
+- name: Gather OS specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
+    - "{{ ansible_distribution }}.yml"
 
 - name: Debug ansible devices
   debug:

--- a/ansible/roles/atmo-mount-volume/tasks/main.yml
+++ b/ansible/roles/atmo-mount-volume/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 
-- name: Set MOUNT_OPTS Ubuntu < 16
+- name: Set VOLUME_OPTS Ubuntu < 16
   set_fact:
-    MOUNT_OPTS: 'defaults,nobootwait'
+    VOLUME_OPTS: 'defaults,nobootwait'
   when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version < "16"
 
 - name: Debug ansible devices

--- a/ansible/roles/atmo-mount-volume/tasks/main.yml
+++ b/ansible/roles/atmo-mount-volume/tasks/main.yml
@@ -16,7 +16,7 @@
     src: '{{ VOLUME_DEVICE }}'
     state: 'mounted'
     path: '{{ VOLUME_MOUNT_LOCATION }}'
-    opts: 'nobootwait'
+    opts: 'nofail'
     passno: '2'
   register: mount_result
 

--- a/ansible/roles/atmo-mount-volume/tasks/main.yml
+++ b/ansible/roles/atmo-mount-volume/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Set MOUNT_OPTS Ubuntu < 16
   set_fact:
-    MOUNT_OPTS: 'nobootwait'
+    MOUNT_OPTS: 'defaults,nobootwait'
   when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version < "16"
 
 - name: Debug ansible devices

--- a/ansible/roles/atmo-mount-volume/tasks/main.yml
+++ b/ansible/roles/atmo-mount-volume/tasks/main.yml
@@ -3,8 +3,10 @@
 - name: Gather OS specific variables
   include_vars: "{{ item }}"
   with_first_found:
-    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
-    - "{{ ansible_distribution }}.yml"
+    - files:
+        - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
+        - "{{ ansible_distribution }}.yml"
+      skip: true
 
 - name: Debug ansible devices
   debug:

--- a/ansible/roles/atmo-mount-volume/tasks/main.yml
+++ b/ansible/roles/atmo-mount-volume/tasks/main.yml
@@ -16,6 +16,8 @@
     src: '{{ VOLUME_DEVICE }}'
     state: 'mounted'
     path: '{{ VOLUME_MOUNT_LOCATION }}'
+    opts: 'nobootwait'
+    passno: '2'
   register: mount_result
 
 - name: Debug mount result

--- a/ansible/roles/atmo-mount-volume/tasks/main.yml
+++ b/ansible/roles/atmo-mount-volume/tasks/main.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: Set MOUNT_OPTS Ubuntu < 16
+  set_fact:
+    MOUNT_OPTS: 'nobootwait'
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version < "16"
+
 - name: Debug ansible devices
   debug:
     var: item
@@ -16,7 +21,7 @@
     src: '{{ VOLUME_DEVICE }}'
     state: 'mounted'
     path: '{{ VOLUME_MOUNT_LOCATION }}'
-    opts: 'nofail'
+    opts: '{{ MOUNT_OPTS }}'
     passno: '2'
   register: mount_result
 

--- a/ansible/roles/atmo-mount-volume/vars/Ubuntu-14.yml
+++ b/ansible/roles/atmo-mount-volume/vars/Ubuntu-14.yml
@@ -1,0 +1,3 @@
+---
+
+VOLUME_OPTS: "defaults,nobootwait"


### PR DESCRIPTION
If a volume is removed without using the [atmosphere-ansible unmount_volume playbook](https://github.com/cyverse/atmosphere-ansible/blob/master/ansible/playbooks/instance_actions/unmount_volume.yml), the instance will fail to boot after being rebooted/redeployed/resumed because a disk in `/etc/fstab` is missing. It appears to be stuck in "Networking" which is confusing since it is not a networking problem.

Once a failure like this is diagnosed, it is still not straightforward or easy to fix.

This PR adds the 'nobootwait' or 'nofail' option to the `/etc/fstab` line of the mounted disk. This allows instances to boot even if the volume is missing. 'nofail' is used on all instances except Ubuntu 14 instances which use 'nobootwait'. These fstab changes are made for ephemeral disks and mounted volumes.