### PR TITLE
small fix to mount task to remove device entries in fstab

### DIFF
--- a/ansible/roles/unmount-volume/tasks/main.yml
+++ b/ansible/roles/unmount-volume/tasks/main.yml
@@ -25,7 +25,7 @@
     name: "{{ (item |from_json )[0] }}"
     src: "{{ src }}"
     fstype: "{{ (item |from_json )[1] }}"
-    state: unmounted
+    state: absent
   register: unmount_result
   with_items:
     - "{{ list_mount_result.stdout_lines }}"


### PR DESCRIPTION
Small change that will set the state to absent, which will cleanly remove the corresponding fstab entries