### PR TITLE
fixed the passno and mount options for the mount task in atmo-mount-volume role

### DIFF
--- a/ansible/roles/atmo-mount-volume/README.md
+++ b/ansible/roles/atmo-mount-volume/README.md
@@ -11,6 +11,7 @@ Role Variables
 | VOLUME_DEVICE           | yes      |         |                           | Location of the device to mount          |
 | VOLUME_DEVICE_TYPE      | yes      |         |                           | Filesystem type of device                |
 | VOLUME_MOUNT_LOCATION   | yes      |         |                           | Location to mount                        |
+| VOLUME_PASSNO           | no       |   2     |                           | see fstab 5                              |
 | ATMOUSERNAME            | yes      |         |                           | User that should own the volume          |
 
 Example Playbook

--- a/ansible/roles/atmo-mount-volume/README.md
+++ b/ansible/roles/atmo-mount-volume/README.md
@@ -6,13 +6,14 @@ Mounts a volume on Atmosphere instance.
 Role Variables
 --------------
 
-| Variable                | Required | Default | Choices                   | Comments                                 |
-|-------------------------|----------|---------|---------------------------|------------------------------------------|
-| VOLUME_DEVICE           | yes      |         |                           | Location of the device to mount          |
-| VOLUME_DEVICE_TYPE      | yes      |         |                           | Filesystem type of device                |
-| VOLUME_MOUNT_LOCATION   | yes      |         |                           | Location to mount                        |
-| VOLUME_PASSNO           | no       |   2     |                           | see fstab 5                              |
-| ATMOUSERNAME            | yes      |         |                           | User that should own the volume          |
+| Variable                | Required | Default         | Choices                   | Comments                                 |
+|-------------------------|----------|-----------------|---------------------------|------------------------------------------|
+| VOLUME_DEVICE           | yes      |                 |                           | Location of the device to mount          |
+| VOLUME_DEVICE_TYPE      | yes      |                 |                           | Filesystem type of device                |
+| VOLUME_MOUNT_LOCATION   | yes      |                 |                           | Location to mount                        |
+| VOLUME_PASSNO           | no       |   2             |                           | see fstab 5                              |
+| VOLUME_OPTS             | no       | defaults,nofail |                           | see fstab 5                              |
+| ATMOUSERNAME            | yes      |                 |                           | User that should own the volume          |
 
 Example Playbook
 ----------------

--- a/ansible/roles/atmo-mount-volume/defaults/main.yml
+++ b/ansible/roles/atmo-mount-volume/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 
 ATMO_USER_GROUP: "users"
+
+VOLUME_PASSNO: "2"

--- a/ansible/roles/atmo-mount-volume/defaults/main.yml
+++ b/ansible/roles/atmo-mount-volume/defaults/main.yml
@@ -2,4 +2,6 @@
 
 ATMO_USER_GROUP: "users"
 
+VOLUME_OPTS: "defaults,nofail"
+
 VOLUME_PASSNO: "2"

--- a/ansible/roles/atmo-mount-volume/tasks/main.yml
+++ b/ansible/roles/atmo-mount-volume/tasks/main.yml
@@ -17,6 +17,7 @@
     state: 'mounted'
     path: '{{ VOLUME_MOUNT_LOCATION }}'
     passno: '{{ VOLUME_PASSNO }}'
+    opts: '{{ VOLUME_OPTS }}'
   register: mount_result
 
 - name: Debug mount result

--- a/ansible/roles/atmo-mount-volume/tasks/main.yml
+++ b/ansible/roles/atmo-mount-volume/tasks/main.yml
@@ -16,6 +16,7 @@
     src: '{{ VOLUME_DEVICE }}'
     state: 'mounted'
     path: '{{ VOLUME_MOUNT_LOCATION }}'
+    passno: '{{ VOLUME_PASSNO }}'
   register: mount_result
 
 - name: Debug mount result


### PR DESCRIPTION
Added a new default variable named VOLUME_PASSNO, which maps the the fstab option for passno, and defaults to 2 (i.e. non-root filesystems).