### PR TITLE
 Create desktop shortcut to change the display resolution

### DIFF
--- a/ansible/roles/atmo-gui-tweaks/files/change_resolution.desktop
+++ b/ansible/roles/atmo-gui-tweaks/files/change_resolution.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Version=1.0
+Name=change_desktop_resolution
+comment=Change desktop resolution
+Exec=/opt/cyverse_change_resolution.sh
+Terminal=true
+Type=Application
+Categories=Utility

--- a/ansible/roles/atmo-gui-tweaks/files/cyverse_change_resolution.sh
+++ b/ansible/roles/atmo-gui-tweaks/files/cyverse_change_resolution.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+xrandr -q | head -n -4
+
+read -p "Enter number or resolution:" res
+xrandr -s $res

--- a/ansible/roles/atmo-gui-tweaks/tasks/change-display-resolution.yml
+++ b/ansible/roles/atmo-gui-tweaks/tasks/change-display-resolution.yml
@@ -1,0 +1,12 @@
+---
+- name: Copy script to change desktop resolution
+  copy:
+    src: 'files/cyverse_change_resolution.sh'
+    dest: '/opt/cyverse_change_resolution.sh'
+    mode: '0755'
+
+- name: Copy desktop icon for changing desktop resolution
+  copy:
+    src: 'files/change_resolution.desktop'
+    dest: '/home/{{ ATMOUSERNAME }}/Desktop/change_resolution.desktop'
+    mode: '0755'

--- a/ansible/roles/atmo-gui-tweaks/tasks/main.yml
+++ b/ansible/roles/atmo-gui-tweaks/tasks/main.yml
@@ -47,3 +47,9 @@
   when:
     - has_gui
     - SET_DESKTOP_BACKGROUND is defined and SET_DESKTOP_BACKGROUND == true
+
+- name: add desktop shortcut to change display resolution
+  include: 'change-display-resolution.yml'
+  ignore_errors: yes
+  when:
+    - has_gui


### PR DESCRIPTION
The default display resolution for VNC sessions is 1024x768, which does not give the user much room to work with. If users browse through the wiki they would be able to find the command to change the resolution, but I assume many don't know that is an option. This PR will allow users to easily choose from all the available resolution options.

![32623053-254ec418-c542-11e7-9000-e432b893fc10](https://user-images.githubusercontent.com/19335917/36800606-227112f0-1c6d-11e8-9f9b-8cd9e9339e4b.gif)

re-created #130 because this moves everything to the new `atmo-gui-tweaks` role from #137 (which should be merged first)