### PR TITLE
Fix instances fail to boot if a volume is removed outside atmosphere

### DIFF
--- a/ansible/roles/atmo-ephemeral-mount/defaults/main.yml
+++ b/ansible/roles/atmo-ephemeral-mount/defaults/main.yml
@@ -4,3 +4,5 @@ disk_mounted_elsewhere: false
 
 MOUNT_PATH: '/scratch'
 MOUNT_TYPE: 'ext4'
+MOUNT_OPTS: 'defaults,nofail'
+MOUNT_PASSNO: '2'

--- a/ansible/roles/atmo-ephemeral-mount/tasks/main.yml
+++ b/ansible/roles/atmo-ephemeral-mount/tasks/main.yml
@@ -1,5 +1,13 @@
 ---
 
+- name: Gather OS specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+        - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
+        - "{{ ansible_distribution }}.yml"
+      skip: true
+
 - name: 'See if we have an ephemeral disk'
   stat:
     path: '/dev/disk/by-label/ephemeral0'
@@ -33,6 +41,8 @@
       src: '{{ ephem_stat.stat.lnk_source }}'
       fstype: '{{ MOUNT_TYPE }}'
       state: 'mounted'
+      opts: '{{ MOUNT_OPTS }}'
+      passno: '{{ MOUNT_PASSNO }}'
 
   - name: 'Data loss warning for Ephemeral storage'
     copy:

--- a/ansible/roles/atmo-ephemeral-mount/vars/Ubuntu-14.yml
+++ b/ansible/roles/atmo-ephemeral-mount/vars/Ubuntu-14.yml
@@ -1,0 +1,3 @@
+---
+
+MOUNT_OPTS: 'defaults,nobootwait'

--- a/ansible/roles/atmo-mount-volume/README.md
+++ b/ansible/roles/atmo-mount-volume/README.md
@@ -6,12 +6,14 @@ Mounts a volume on Atmosphere instance.
 Role Variables
 --------------
 
-| Variable                | Required | Default | Choices                   | Comments                                 |
-|-------------------------|----------|---------|---------------------------|------------------------------------------|
-| VOLUME_DEVICE           | yes      |         |                           | Location of the device to mount          |
-| VOLUME_DEVICE_TYPE      | yes      |         |                           | Filesystem type of device                |
-| VOLUME_MOUNT_LOCATION   | yes      |         |                           | Location to mount                        |
-| ATMOUSERNAME            | yes      |         |                           | User that should own the volume          |
+| Variable                | Required | Default         | Choices                   | Comments                                 |
+|-------------------------|----------|-----------------|---------------------------|------------------------------------------|
+| VOLUME_DEVICE           | yes      |                 |                           | Location of the device to mount          |
+| VOLUME_DEVICE_TYPE      | yes      |                 |                           | Filesystem type of device                |
+| VOLUME_MOUNT_LOCATION   | yes      |                 |                           | Location to mount                        |
+| VOLUME_PASSNO           | no       |   2             |                           | see fstab 5                              |
+| VOLUME_OPTS             | no       | defaults,nofail |                           | see fstab 5                              |
+| ATMOUSERNAME            | yes      |                 |                           | User that should own the volume          |
 
 Example Playbook
 ----------------

--- a/ansible/roles/atmo-mount-volume/defaults/main.yml
+++ b/ansible/roles/atmo-mount-volume/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 
 ATMO_USER_GROUP: "users"
+VOLUME_OPTS: "defaults,nofail"
+VOLUME_PASSNO: "2"

--- a/ansible/roles/atmo-mount-volume/tasks/main.yml
+++ b/ansible/roles/atmo-mount-volume/tasks/main.yml
@@ -1,5 +1,13 @@
 ---
 
+- name: Gather OS specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+        - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
+        - "{{ ansible_distribution }}.yml"
+      skip: true
+
 - name: Debug ansible devices
   debug:
     var: item
@@ -16,6 +24,8 @@
     src: '{{ VOLUME_DEVICE }}'
     state: 'mounted'
     path: '{{ VOLUME_MOUNT_LOCATION }}'
+    passno: '{{ VOLUME_PASSNO }}'
+    opts: '{{ VOLUME_OPTS }}'
   register: mount_result
 
 - name: Debug mount result

--- a/ansible/roles/atmo-mount-volume/vars/Ubuntu-14.yml
+++ b/ansible/roles/atmo-mount-volume/vars/Ubuntu-14.yml
@@ -1,0 +1,3 @@
+---
+
+VOLUME_OPTS: "defaults,nobootwait"


### PR DESCRIPTION
This is a squashed variant of #134

I performed the squash because the history was pretty twisted. I verified that my squash produced the same resulting code as the direct merge of #134 