### PR TITLE
Add missing ATMO_USER var to script env

### DIFF
--- a/ansible/roles/atmo-user-deployment-scripts/tasks/main.yml
+++ b/ansible/roles/atmo-user-deployment-scripts/tasks/main.yml
@@ -32,7 +32,7 @@
 # Subspace uses this `register` variable to determine RC (return-code)
 #
 - name: deploy_script_3 - Run deploy boot scripts synchronously, register results and return if failure occurs.
-  command: "{{INSTANCE_SCRIPT_DIR}}/{{item.name}}"
+  shell: "ATMO_USER={{ATMOUSERNAME}} {{INSTANCE_SCRIPT_DIR}}/{{item.name}}"
   register: "deploy_script_result"
   with_items: '{{ DEPLOY_SCRIPTS }}'
 


### PR DESCRIPTION
Problem: DEPLOY_SCRIPTS are not called with ATMO_USER env variable
Solution: Use the shell module which supports setting variables

From the code this just looks like an oversight, because ASYNC_SCRIPTS get the
variable.