### PR TITLE
Improve logging of asynchronous deployment scripts

### DIFF
--- a/ansible/roles/atmo-user-deployment-scripts/defaults/main.yml
+++ b/ansible/roles/atmo-user-deployment-scripts/defaults/main.yml
@@ -7,16 +7,6 @@ POST_SCRIPT_LOG_DIR: /var/log/atmo/post-scripts
 
 POST_MAKE_DIRS:
   - "{{ SCRIPTS_ROOT }}"
-  - "{{ POST_SCRIPT_DIR }}"
   - "{{ INSTANCE_SCRIPT_AVAILABLE_DIR }}"
   - "{{ INSTANCE_SCRIPT_DIR }}"
-  - "{{ POST_SCRIPT_LOG_DIR }}"
   - "{{ INSTANCE_SCRIPT_LOG_DIR }}"
-
-# NOTE:
-# I believe what accounts for the name "post-scripts" is that they are run
-# _after_ all other scripts. And, "post-scripts" (if present) were part of
-# the image used to launch the instance.
-ASYNC_RUN_SCRIPTS:
-  - { log: "{{ INSTANCE_SCRIPT_LOG_DIR }}", dir: "{{ INSTANCE_SCRIPT_DIR }}" }
-  - { log: "{{ POST_SCRIPT_LOG_DIR }}", dir: "{{ POST_SCRIPT_DIR }}" }

--- a/ansible/roles/atmo-user-deployment-scripts/tasks/main.yml
+++ b/ansible/roles/atmo-user-deployment-scripts/tasks/main.yml
@@ -58,24 +58,19 @@
     state: link
   with_items: '{{ ASYNC_SCRIPTS }}'
 
-
-- name: deploy_script_6a - Get list of scripts in '{{ INSTANCE_SCRIPT_DIR }}'
-  command: 'ls {{ INSTANCE_SCRIPT_DIR }}'
-  register: AVAILABLE_SCRIPTS
-
-- name: deploy_script_6b - Execute scripts
-  shell: 'ATMO_USER={{ ATMOUSERNAME }} nohup {{ INSTANCE_SCRIPT_DIR }}/{{ item }} &'
+- name: deploy_script_6a - Execute scripts
+  shell: 'ATMO_USER={{ ATMOUSERNAME }} nohup {{ INSTANCE_SCRIPT_DIR }}/{{ item.name }} &'
   register: SCRIPT_RESULT
-  with_items: '{{ AVAILABLE_SCRIPTS.stdout_lines }}'
+  with_items: '{{ ASYNC_SCRIPTS }}'
 
-- name: deploy_script_6c - Register date
+- name: deploy_script_6b - Register date
   command: 'date +"%Y-%m-%d-%H:%M"'
   register: DATE
 
-- name: deploy_script_6d - Create logs
+- name: deploy_script_6c - Create logs
   template:
     src: 'deploy_log.j2'
-    dest: '{{ INSTANCE_SCRIPT_LOG_DIR }}/{{ item.item }}_{{ DATE.stdout }}.log'
+    dest: '{{ INSTANCE_SCRIPT_LOG_DIR }}/{{ item.item.name }}_{{ DATE.stdout }}.log'
   with_items: '{{ SCRIPT_RESULT.results }}'
 
 - name: deploy_script_7 - Remove instance scripts to avoid being picked up on next run

--- a/ansible/roles/atmo-user-deployment-scripts/tasks/main.yml
+++ b/ansible/roles/atmo-user-deployment-scripts/tasks/main.yml
@@ -58,30 +58,25 @@
     state: link
   with_items: '{{ ASYNC_SCRIPTS }}'
 
-#Future TODO:
-# - If possible, refactor these components into ansible:
-#   - get name of  each file in script directory
-#   - if file is executable, generate 'dynamic log files' based on 'script|basename' and 'date()'
-#   - if file is executable, run ` set -m; nohup-call-to-file..` and point to dynamic log files from above.
-- name: deploy_script_6b - execute scripts found in ASYNC_RUN_SCRIPTS asynchronously
-  shell: |
-    set -m  # allows backgrounded processes to persist
-    for SCRIPT in {{item.dir}}/*;
-    do
-      if [[ -f $SCRIPT && -x $SCRIPT ]]; then
-        LOG_DIR="{{item.log}}"
-        BASENAME=${SCRIPT##*/}
-        DATE=$(date +%F_%T)
-        SCRIPT_STDOUT=$LOG_DIR/$BASENAME.$DATE.stdout
-        SCRIPT_STDERR=$LOG_DIR/$BASENAME.$DATE.stderr
-        ATMO_USER={{ATMOUSERNAME}} nohup $SCRIPT >$SCRIPT_STDOUT 2>$SCRIPT_STDERR </dev/null &
-      fi
-    done
-    exit 0
-  args:
-    executable: /bin/bash
-  register: shell_result
-  with_items: '{{ ASYNC_RUN_SCRIPTS }}'
+
+- name: deploy_script_6a - Get list of scripts in '{{ INSTANCE_SCRIPT_DIR }}'
+  command: 'ls {{ INSTANCE_SCRIPT_DIR }}'
+  register: AVAILABLE_SCRIPTS
+
+- name: deploy_script_6b - Execute scripts
+  shell: 'set -m; ATMO_USER={{ ATMOUSERNAME }} nohup {{ INSTANCE_SCRIPT_DIR }}/{{ item }} &'
+  register: SCRIPT_RESULT
+  with_items: '{{ AVAILABLE_SCRIPTS.stdout_lines }}'
+
+- name: deploy_script_6c - Register date
+  command: 'date +"%Y-%m-%d-%H:%M"'
+  register: DATE
+
+- name: deploy_script_6d - Create logs
+  template:
+    src: 'deploy_log.j2'
+    dest: '{{ INSTANCE_SCRIPT_LOG_DIR }}/{{ DATE.stdout }}_{{ item.item }}.log'
+  with_items: '{{ SCRIPT_RESULT.results }}'
 
 # Helpful if the shell script above fails..
 # - debug: msg="item.item={{item.item}}, item.stdout={{item.stdout}}, item.changed={{item.changed}}"
@@ -92,4 +87,3 @@
     path: "{{INSTANCE_SCRIPT_DIR}}/{{ item.name }}"
     state: absent
   with_items: '{{ ASYNC_SCRIPTS }}'
-

--- a/ansible/roles/atmo-user-deployment-scripts/tasks/main.yml
+++ b/ansible/roles/atmo-user-deployment-scripts/tasks/main.yml
@@ -64,7 +64,7 @@
   register: AVAILABLE_SCRIPTS
 
 - name: deploy_script_6b - Execute scripts
-  shell: 'set -m; ATMO_USER={{ ATMOUSERNAME }} nohup {{ INSTANCE_SCRIPT_DIR }}/{{ item }} &'
+  shell: 'ATMO_USER={{ ATMOUSERNAME }} nohup {{ INSTANCE_SCRIPT_DIR }}/{{ item }} &'
   register: SCRIPT_RESULT
   with_items: '{{ AVAILABLE_SCRIPTS.stdout_lines }}'
 
@@ -75,12 +75,8 @@
 - name: deploy_script_6d - Create logs
   template:
     src: 'deploy_log.j2'
-    dest: '{{ INSTANCE_SCRIPT_LOG_DIR }}/{{ DATE.stdout }}_{{ item.item }}.log'
+    dest: '{{ INSTANCE_SCRIPT_LOG_DIR }}/{{ item.item }}_{{ DATE.stdout }}.log'
   with_items: '{{ SCRIPT_RESULT.results }}'
-
-# Helpful if the shell script above fails..
-# - debug: msg="item.item={{item.item}}, item.stdout={{item.stdout}}, item.changed={{item.changed}}"
-#   with_items: "{{shell_result.results}}"
 
 - name: deploy_script_7 - Remove instance scripts to avoid being picked up on next run
   file:

--- a/ansible/roles/atmo-user-deployment-scripts/templates/deploy_log.j2
+++ b/ansible/roles/atmo-user-deployment-scripts/templates/deploy_log.j2
@@ -2,7 +2,6 @@ Start time: {{ item.start }}
 Finish time: {{ item.end }}
 Command: {{ item.cmd }}
 Changed: {{ item.changed }}
-Failed: {{ item.failed }}
 Return Code: {{ item.rc }}
 
 stderr_lines:

--- a/ansible/roles/atmo-user-deployment-scripts/templates/deploy_log.j2
+++ b/ansible/roles/atmo-user-deployment-scripts/templates/deploy_log.j2
@@ -1,0 +1,16 @@
+Start time: {{ item.start }}
+Finish time: {{ item.end }}
+Command: {{ item.cmd }}
+Changed: {{ item.changed }}
+Failed: {{ item.failed }}
+Return Code: {{ item.rc }}
+
+stderr_lines:
+{% for line in item.stderr_lines %}
+  {{ line }}
+{% endfor %}
+
+stdout_lines:
+{% for line in item.stdout_lines %}
+  {{ line }}
+{% endfor %}


### PR DESCRIPTION
This PR addresses a "Future TODO" found in the `atmo-user-deployment-scripts` role:
```
#Future TODO:
# - If possible, refactor these components into ansible:
#   - get name of  each file in script directory
#   - if file is executable, generate 'dynamic log files' based on 'script|basename' and 'date()'
#   - if file is executable, run ` set -m; nohup-call-to-file..` and point to dynamic log files from above.
```

The new way of logging async scripts gets a list of files in the directory, runs them, then creates easy to read logs with a template and Ansible's output from the scripts. I removed `set -m;` because it always resulted in this error: `/bin/sh: 1: set: can't access tty; job control turned off`

I confirmed that the different scripts are executed asynchronously by creating 3 scripts that echo to the same file after different sleep times. The scripts are all run one after the other, without waiting for one to finish, and echo to `/etc/script-test`. The expected file:
```
async3 - 1
async3 - 2
async2 - 1
async1 - 1
async2 - 2
async1 - 2
```
Notice how the output from the last run script (`async3`) is first in the file, and the lines from `async1` and `async2` are alternated. This was matched by the actual result. If I run the same scripts synchronously, the file is:
```
async1 - 1
async1 - 2
async2 - 1
async2 - 2
async3 - 1
async3 - 2
```
Lines are all in order since each script was run one after the other, waiting for the previous script to finish.

<details>
  <summary>Expand to see scripts</summary>

  ```bash
  #!/bin/bash
  # async1
  sleep 10
  echo "async1 - 1" >> /etc/script-test
  sleep 3
  echo "async1 - 2" >> /etc/script-test
  ```

  ```bash
  #!/bin/bash
  # async2
  sleep 5
  echo "async2 - 1" >> /etc/script-test
  sleep 5
  echo "async2 - 2" >> /etc/script-test
  ```

  ```bash
  #!/bin/bash
  # async3
  echo "async3 - 1" >> /etc/script-test
  echo "async3 - 2" >> /etc/script-test
  ```

  ```bash
  #!/bin/bash
  # async_fail
  echo "This will fail"
  mkdir /etc
  ```
</details>

<details>
  <summary>Expand to see example logs</summary>

  ```bash
  # root@vm142-9:/var/log/atmo/instance-scripts# cat async1_2018-04-11-09\:22.log
  Start time: 2018-04-11 09:22:52.866810
  Finish time: 2018-04-11 09:22:53.869364
  Command: ATMO_USER=calvinmclean nohup /etc/atmo/instance-scripts.d/async1 &
  Changed: True
  Return Code: 0

  stderr_lines:

  stdout_lines:
  ```
  ```bash
  # root@vm142-9:/var/log/atmo/instance-scripts# cat async2_2018-04-11-09\:22.log
  Start time: 2018-04-11 09:22:54.041851
  Finish time: 2018-04-11 09:22:55.044342
  Command: ATMO_USER=calvinmclean nohup /etc/atmo/instance-scripts.d/async2 &
  Changed: True
  Return Code: 0

  stderr_lines:

  stdout_lines:
  ```
  ```bash
  # root@vm142-9:/var/log/atmo/instance-scripts# cat async3_2018-04-11-09\:22.log
  Start time: 2018-04-11 09:22:55.213044
  Finish time: 2018-04-11 09:22:55.216293
  Command: ATMO_USER=calvinmclean nohup /etc/atmo/instance-scripts.d/async3 &
  Changed: True
  Return Code: 0

  stderr_lines:

  stdout_lines:
  ```
  ```bash
  # root@vm142-9:/var/log/atmo/instance-scripts# cat async_fail_2018-04-11-09\:22.log
  Start time: 2018-04-11 09:22:55.381186
  Finish time: 2018-04-11 09:22:55.385458
  Command: ATMO_USER=calvinmclean nohup /etc/atmo/instance-scripts.d/async_fail &
  Changed: True
  Return Code: 0

  stderr_lines:
    mkdir: cannot create directory ‘/etc’: File exists

  stdout_lines:
    This will fail
  ```
</details>