### PR TITLE
Configure CentOS to disregard previously configured NTP servers in ntp.conf when using DHCP-provided NTP servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/atmosphere/compare/...HEAD) - YYYY-MM-DD
+
+### Added
+
+- On CentOS, the dhclient.d script `ntp.sh` is configured to remove previously
+  configured NTP servers in ntp.conf when installing DHCP-provided NTP
+  servers. ([#146](https://github.com/cyverse/atmosphere-ansible/pull/146))

--- a/ansible/roles/atmo-ntp/tasks/main.yml
+++ b/ansible/roles/atmo-ntp/tasks/main.yml
@@ -107,7 +107,9 @@
     owner: 'root'
     mode: 'u=rwx,g=rx,o=rx'
   with_first_found:
-    - '{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.ntp.sh.j2'
+    - files:
+        - '../templates/{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.ntp.sh.j2'
+      skip: true
   when: 'ansible_distribution == "CentOS"'
 
 - name: 'Renew DHCP lease for CentOS'

--- a/ansible/roles/atmo-ntp/tasks/main.yml
+++ b/ansible/roles/atmo-ntp/tasks/main.yml
@@ -100,6 +100,20 @@
     - template
   when: SET_NTP_SERVERS == true
 
+- name: 'Place CentOS ntp.sh (dhclient.d script) which removes pre-existing NTP servers from ntp.conf when setting DHCP-provided NTP servers'
+  template:
+    src: '{{ item }}'
+    dest: '/etc/dhcp/dhclient.d/ntp.sh'
+    owner: 'root'
+    mode: 'u=rwx,g=rx,o=rx'
+  with_first_found:
+    - '{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.ntp.sh.j2'
+  when: 'ansible_distribution == "CentOS"'
+
+- name: 'Renew DHCP lease for CentOS'
+  command: 'dhclient -r'
+  when: 'ansible_distribution == "CentOS"'
+
 - name: start ntp service
   action: >
     service name={{ NTP_SERVICE }} state=restarted enabled=yes

--- a/ansible/roles/atmo-ntp/tasks/main.yml
+++ b/ansible/roles/atmo-ntp/tasks/main.yml
@@ -111,7 +111,7 @@
   when: 'ansible_distribution == "CentOS"'
 
 - name: 'Renew DHCP lease for CentOS'
-  command: 'dhclient -r'
+  command: 'dhclient'
   when: 'ansible_distribution == "CentOS"'
 
 - name: start ntp service

--- a/ansible/roles/atmo-ntp/templates/CentOS-6.ntp.sh.j2
+++ b/ansible/roles/atmo-ntp/templates/CentOS-6.ntp.sh.j2
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# ntp.sh: dhclient-script plugin for NTP settings,
+#         place in /etc/dhcp/dhclient.d and 'chmod +x ntp.sh' to enable
+#
+# Copyright (C) 2008 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Author(s): David Cantrell <dcantrell@redhat.com>
+#            Miroslav Lichvar <mlichvar@redhat.com>
+#
+
+CONF=/etc/ntp.conf
+SAVECONF=${SAVEDIR}/${CONF##*/}.predhclient.${interface}
+
+ntp_replace_conf() {
+        echo "$1" | diff -q ${CONF} - > /dev/null 2>&1
+        if [ $? -eq 1 ]; then
+            echo "$1" > ${CONF}
+            restorecon ${CONF} >/dev/null 2>&1
+            service ntpd condrestart >/dev/null 2>&1
+        fi
+}
+
+ntp_config() {
+    if [ ! "${PEERNTP}" = "no" ] && [ -n "${new_ntp_servers}" ] &&
+        [ -e ${CONF} ] && [ -d ${SAVEDIR} ]; then
+        local conf=$(egrep -v '^server .*$' < ${CONF})
+        local unique_servers=$(comm -23 \
+            <(for s in ${new_ntp_servers}; do echo $s; done | sort -u) \
+            <(echo "$conf" | awk '$1=="peer"||$1=="server"{print $2}' | sort -u))
+
+        conf=$(echo "$conf"
+            for s in ${unique_servers}; do
+                echo "server ${s}  # added by /sbin/dhclient-script"
+            done)
+
+        [ -f ${SAVECONF} ] || touch ${SAVECONF}
+        ntp_replace_conf "$conf"
+    fi
+}
+
+ntp_restore() {
+    if [ -e ${CONF} ] && [ -f ${SAVECONF} ]; then
+        local conf=$(egrep -v '^server .*  # added by /sbin/dhclient-script$' < ${CONF})
+
+        ntp_replace_conf "$conf"
+        rm -f ${SAVECONF}
+    fi
+}

--- a/ansible/roles/atmo-ntp/templates/CentOS-7.ntp.sh.j2
+++ b/ansible/roles/atmo-ntp/templates/CentOS-7.ntp.sh.j2
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# ntp.sh: dhclient-script plugin for NTP settings,
+#         place in /etc/dhcp/dhclient.d and 'chmod +x ntp.sh' to enable
+#
+# Copyright (C) 2008 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Author(s): David Cantrell <dcantrell@redhat.com>
+#            Miroslav Lichvar <mlichvar@redhat.com>
+#
+
+CONF=/etc/ntp.conf
+SAVECONF=${SAVEDIR}/${CONF##*/}.predhclient.${interface}
+
+ntp_replace_conf() {
+        echo "$1" | diff -q ${CONF} - > /dev/null 2>&1
+        if [ $? -eq 1 ]; then
+            echo "$1" > ${CONF}
+            restorecon ${CONF} >/dev/null 2>&1
+            systemctl try-restart ntpd.service > /dev/null 2>&1 ||
+                service ntpd condrestart > /dev/null 2>&1
+        fi
+}
+
+ntp_config() {
+    if [ ! "${PEERNTP}" = "no" ] && [ -n "${new_ntp_servers}" ] &&
+        [ -e ${CONF} ] && [ -d ${SAVEDIR} ]; then
+        local conf=$(grep -v '^server .*$' < ${CONF})
+        local unique_servers=$(comm -23 \
+            <(for s in ${new_ntp_servers}; do echo $s; done | sort -u) \
+            <(echo "$conf" | awk '$1=="peer"||$1=="server"{print $2}' | sort -u))
+
+        conf=$(echo "$conf"
+            for s in ${unique_servers}; do
+                echo "server ${s} ${NTPSERVERARGS}  # added by /sbin/dhclient-script"
+            done)
+
+        [ -f ${SAVECONF} ] || touch ${SAVECONF}
+        ntp_replace_conf "$conf"
+    fi
+}
+
+ntp_restore() {
+    if [ -e ${CONF} ] && [ -f ${SAVECONF} ]; then
+        local conf=$(grep -v '^server .*  # added by /sbin/dhclient-script$' < ${CONF})
+
+        ntp_replace_conf "$conf"
+        rm -f ${SAVECONF}
+    fi
+}


### PR DESCRIPTION
## Description

See [JETSTREAM-22](https://iujetstream.atlassian.net/browse/JETSTREAM-22)

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [x] Add an entry in the changelog
- [ ] Documentation created/updated (include links)
- [x] Reviewed and approved by at least one other contributor.
- [ ] New variables contributed to atmosphere/Clank