### PR TITLE
Add desktop icon and python script to change resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
   configured NTP servers in ntp.conf when installing DHCP-provided NTP
   servers. ([#146](https://github.com/cyverse/atmosphere-ansible/pull/146))
 
+- Python app for changing the desktop resolution on instances using a GUI dropdown menu. The app is accessible from desktop icon or applications menu ([#149](https://github.com/cyverse/atmosphere-ansible/pull/149))
+
 ### Fixed
 
 - Fixed task to kill VNC servers using `pkill` instead of `vncserver -kill :$DISPLAY` ([#150](https://github.com/cyverse/atmosphere-ansible/pull/150))

--- a/ansible/roles/atmo-gui-tweaks/files/change_res.py
+++ b/ansible/roles/atmo-gui-tweaks/files/change_res.py
@@ -1,0 +1,54 @@
+#!/usr/bin/python
+from Tkinter import *
+from subprocess import PIPE, Popen, call
+
+def change_res(res):
+   call(("/usr/bin/xrandr -s %s" % res).split(), stdout=PIPE)
+   selection = "\nYour new resolution is " + res
+   text.config(text = selection)
+
+def get_res():
+    xrandr_lines = Popen("/usr/bin/xrandr", stdout=PIPE).communicate()[0].split("\n")
+    for line in xrandr_lines:
+        if '*' in line:
+            return ''.join(line.split()[1:4])
+
+resolutions = [
+        "1024x700",
+        "1024x768",
+        "1200x740",
+        "1280x800",
+        "1280x960",
+        "1280x1024",
+        "1600x1000",
+        "1600x1200",
+        "1680x1050",
+        "1920x1080",
+        "1920x1200",
+        "3200x1000",
+        "3200x1200",
+        "3360x1050"
+        ]
+
+# Create window
+window = Tk()
+window.title("Change Desktop Resolution")
+
+# Create label
+label_var = StringVar()
+label = Label(window, textvariable = label_var)
+label_var.set("Select desired desktop resolution\n")
+label.pack()
+
+# Get current resolution
+cur_res = get_res()
+
+var = StringVar(window)
+var.set(cur_res)
+
+text = Label(window)
+menu = OptionMenu(window, var, *resolutions, command=change_res)
+
+menu.pack()
+text.pack()
+window.mainloop()

--- a/ansible/roles/atmo-gui-tweaks/files/change_resolution.desktop
+++ b/ansible/roles/atmo-gui-tweaks/files/change_resolution.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Version=1.0
+Name=Change Desktop Resolution
+comment=Change Desktop Resolution
+Exec=/usr/bin/python /opt/change_res.py
+Type=Application
+Categories=Accessories;Settings;System

--- a/ansible/roles/atmo-gui-tweaks/tasks/desktop-resolution.yml
+++ b/ansible/roles/atmo-gui-tweaks/tasks/desktop-resolution.yml
@@ -1,0 +1,24 @@
+---
+
+- name: Install python-tkinter for GUI application
+  package:
+    name: '{{ TKINTER }}'
+    state: present
+
+- name: Copy python program to change desktop resolution
+  copy:
+    src: 'files/change_res.py'
+    dest: '/opt/change_res.py'
+
+- name: Copy desktop icon for changing desktop resolution
+  copy:
+    src: 'files/change_resolution.desktop'
+    dest: '/home/{{ ATMOUSERNAME }}/Desktop/change_resolution.desktop'
+    owner: '{{ ATMOUSERNAME }}'
+    mode: '0755'
+
+- name: Add launcher to applications menu
+  copy:
+    src: 'files/change_resolution.desktop'
+    dest: '/usr/share/applications/change_resolution.desktop'
+    mode: '0644'

--- a/ansible/roles/atmo-gui-tweaks/tasks/main.yml
+++ b/ansible/roles/atmo-gui-tweaks/tasks/main.yml
@@ -47,3 +47,9 @@
   when:
     - has_gui
     - SET_DESKTOP_BACKGROUND is defined and SET_DESKTOP_BACKGROUND == true
+
+- name: add desktop shortcut to change display resolution
+  include: 'desktop-resolution.yml'
+  ignore_errors: yes
+  when:
+    - has_gui

--- a/ansible/roles/atmo-gui-tweaks/vars/CentOS.yml
+++ b/ansible/roles/atmo-gui-tweaks/vars/CentOS.yml
@@ -1,3 +1,5 @@
 XGUI:
   xsession_path: /usr/bin/xinit
   xterm_path: /usr/bin/Xorg
+
+TKINTER: 'tkinter'

--- a/ansible/roles/atmo-gui-tweaks/vars/Ubuntu.yml
+++ b/ansible/roles/atmo-gui-tweaks/vars/Ubuntu.yml
@@ -1,3 +1,5 @@
 XGUI:
   xsession_path: /usr/bin/X
   xterm_path: /usr/bin/xinit
+
+TKINTER: 'python-tk'

--- a/ansible/test-pb.yml
+++ b/ansible/test-pb.yml
@@ -1,0 +1,5 @@
+- hosts: atmosphere
+  vars:
+    ATMOUSERNAME: 'calvinmclean'
+  roles:
+    - atmo-gui-tweaks


### PR DESCRIPTION
## Description

This is the third, and probably best, implementation of a feature that allows users to easily change the resolution of their Web Desktop session. This version has a desktop icon and application menu entry to launch a simple GUI python script.

It requires installing python-tkinter on instances.

The version in this PR uses a dropdown menu, but I also made a version with radio buttons that we could use instead.

![screen shot 2018-05-11 at 11 43 24 am](https://user-images.githubusercontent.com/19335917/39941896-d339f380-5512-11e8-830b-b43a83bded84.png)

### Here are some GIFs of usage:

![desktop](https://user-images.githubusercontent.com/19335917/39941917-dd693b04-5512-11e8-92be-98f239b3228c.gif)
![menu](https://user-images.githubusercontent.com/19335917/39941918-dd8faafa-5512-11e8-8ce7-2495b9558843.gif)
