### PR TITLE
ATMO-2077: Fix VNC kill command so that new VNC servers can be started with correct xauth configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - On CentOS, the dhclient.d script `ntp.sh` is configured to remove previously
   configured NTP servers in ntp.conf when installing DHCP-provided NTP
   servers. ([#146](https://github.com/cyverse/atmosphere-ansible/pull/146))
+
+### Fixed
+
+- Fixed task to kill VNC servers using `pkill` instead of `vncserver -kill :$DISPLAY` ([#150](https://github.com/cyverse/atmosphere-ansible/pull/150))

--- a/ansible/roles/atmo-vnc/tasks/realvnc.yml
+++ b/ansible/roles/atmo-vnc/tasks/realvnc.yml
@@ -106,9 +106,7 @@
     mode: 0755
 
 - name: kill all running vncserver sessions
-  shell: >
-    /bin/su '{{ ATMOUSERNAME }}' -c "{{ VNC_EXECUTABLE }} -kill :'{{ item }}'"
-  with_items: [1, 2, 3, 4, 5, 6, 7, 8]
+  command: 'pkill Xvnc-core'
   failed_when: False
 
 - name: Run VNC commands (Add license, set password, start server)


### PR DESCRIPTION
## Description

Problem: when instances are resumed, the existing VNC servers are not killed and restarted, so xauth is not updated with the new hostname. This would cause Web Desktop to refuse to open new windows.

The task that is supposed to kill all existing VNC servers using the command `vncserver -kill :$DISPLAY` does not succeed on instances being resumed. The changes here simply fix the kill task using `pkill` so that new VNC servers can be started. The new VNC servers will naturally update xauth.

More info can be found in Issue #126 and [ATMO-2077](https://pods.iplantcollaborative.org/jira/browse/ATMO-2077)

---