### PR TITLE
Use XFCE or Gnome commands to change background 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,4 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Fixed
 
 - Fixed task to kill VNC servers using `pkill` instead of `vncserver -kill :$DISPLAY` ([#150](https://github.com/cyverse/atmosphere-ansible/pull/150))
+- Fixed task to change desktop background on CentOS 7. This change also offered other improvements by using the correct commands to change the desktop background instead of overwriting existing files ([#151](https://github.com/cyverse/atmosphere-ansible/pull/151))

--- a/ansible/roles/atmo-gui-tweaks/defaults/main.yml
+++ b/ansible/roles/atmo-gui-tweaks/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 
 background_img: 'files/atmosphere_wallpaper_v1.jpg'
+background_dest: '/usr/share/backgrounds/cloud_background.jpg' 
 
 SET_DESKTOP_BACKGROUND: false

--- a/ansible/roles/atmo-gui-tweaks/tasks/desktop-background.yml
+++ b/ansible/roles/atmo-gui-tweaks/tasks/desktop-background.yml
@@ -2,27 +2,32 @@
 - name: Copy desktop background to instance
   copy:
     src: "{{ background_img }}"
-    dest: /usr/share/backgrounds/cloud_background.jpg
+    dest: '{{ background_dest }}'
 
-- name: Change desktop background on CentOS
+- name: check if XFCE is desktop environment
+  stat:
+    path: '/usr/bin/xfce4-session'
+  register: xfce
+
+- name: desktop environment is XFCE
+  set_fact:
+    change_background_cmd: 'xfconf-query -c xfce4-desktop --property /backdrop/screen0/monitor0/workspace0/last-image --create --type string --set'
+  when: xfce.stat.exists
+
+- name: check if Gnome is desktop environment
+  stat:
+    path: '/usr/bin/gnome-session'
+  register: gnome
+
+- name: desktop environment is Gnome
+  set_fact:
+    change_background_cmd: 'gconftool-2 -s -t string /desktop/gnome/background/picture_filename'
+  when: gnome.stat.exists and not xfce.stat.exists
+
+# gsettings requires that a dbus-daemon is running. dbus-launch is used to launch it
+# because it exits and returns environment variables. $() sources these variables so
+# we can kill the PID and avoid having a bunch of rogue dbus-daemons.
+- name: Change desktop background
   become: yes
-  become_user: "{{ ATMOUSERNAME }}"
-  command: >
-    gconftool-2 -s -t string /desktop/gnome/background/picture_filename "/usr/share/backgrounds/cloud_background.jpg"
-  when: ansible_distribution == "CentOS"
-
-# Note: These tasks trick the os by replacing their defaults with our own instead of properly
-# setting the background because "Unable to autolaunch a dbus-daemon without a $DISPLAY for X11"
-- name: Change desktop background on Ubuntu
-  copy:
-    src: /usr/share/backgrounds/cloud_background.jpg
-    dest: /usr/share/backgrounds/default.jpg
-    remote_src: True
-  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version < "16"
-
-- name: Change desktop background on Ubuntu 16+
-  copy:
-    src: /usr/share/backgrounds/cloud_background.jpg
-    dest: /usr/share/backgrounds/xfce/xfce-teal.jpg
-    remote_src: True
-  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= "16"
+  become_user: '{{ ATMOUSERNAME }}'
+  shell: 'export $(dbus-launch); {{ change_background_cmd }} "{{ background_dest }}" && kill $DBUS_SESSION_BUS_PID'


### PR DESCRIPTION
## Description

I noticed that our new CentOS 7 image did not get the correct desktop background change. This is because it uses XFCE desktop while the Ansible role expected CentOS instances to be using Gnome. This fix checks if XFCE commands are available on the instance, and if not, it uses Gnome commands instead.

This is a fix for CentOS 7, but it is also a big improvement to the task because it uses the correct commands to change the desktop background for XFCE instead of replacing the original background file with our own. It also gets rid of the specific checks for Ubuntu 14 and Ubuntu 16+.
