### PR TITLE
Do not change permissions on all files a user's home directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,4 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 - Fixed task to kill VNC servers using `pkill` instead of `vncserver -kill :$DISPLAY` ([#150](https://github.com/cyverse/atmosphere-ansible/pull/150))
 - Fixed task to change desktop background on CentOS 7. This change also offered other improvements by using the correct commands to change the desktop background instead of overwriting existing files ([#151](https://github.com/cyverse/atmosphere-ansible/pull/151))
+- Only modify the permissions when user's home directory is created ([#152](https://github.com/cyverse/atmosphere-ansible/pull/152))

--- a/ansible/roles/atmo-setup-user/tasks/main.yml
+++ b/ansible/roles/atmo-setup-user/tasks/main.yml
@@ -84,11 +84,10 @@
   stat: path="/home/{{ ATMOUSERNAME }}"
   register: atmouser_home
 
-- name: copy skel files into home directory
-  shell: cp -R /etc/skel /home/"{{ ATMOUSERNAME }}"
-  when: not atmouser_home.stat.exists
-
 - block:
+    - name: copy skel files into home directory
+      shell: cp -R /etc/skel /home/"{{ ATMOUSERNAME }}"
+
     - name: Set ownership for user's home, ignoring mounted volumes
       shell: >
         find /home/{{ ATMOUSERNAME }} -mount | xargs chown {{ ATMOUSERNAME }}:iplant-everyone
@@ -98,4 +97,4 @@
       shell: >
         find /home/{{ ATMOUSERNAME }} -mount | xargs chmod 755 {{ ATMOUSERNAME }}:iplant-everyone
       failed_when: False
-  tags: chown_users_home
+  when: not atmouser_home.stat.exists


### PR DESCRIPTION
## Description

Do not change permissions on all files in user home

Rather than changing permissions on every deploy, only change permissions if we create the user directory.

The original problem is that a user was timing out during deploy and it was hanging at this task. The user had 6mil files in their home. I don't think changing permissions would take more than 32min which is the upper limit for the user deploy task, but we shouldn't be changing permissions anyway.

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [x] Reviewed and approved by at least one other contributor.