### PR TITLE
Upgrade Ansible version to the latest (2.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Changed
 
 - Renamed Subspace variables to use Ansible keyword instead of Subspace ([#154](https://github.com/cyverse/atmosphere-ansible/pull/154))
+- Changes to make compatible with Ansible 2.6 free of deprecation warnings ([#155](https://github.com/cyverse/atmosphere-ansible/pull/155))
+- Changed 'template password-auth' task in ldap role for CentOS to say `follow=yes` since before Ansible 2.4 yes was default but now default is no. It is required because the `password-auth` file is a link ([#155](https://github.com/cyverse/atmosphere-ansible/pull/155))
+- Changed task that install iRods on Ubuntu in `atmo-kanki-irodsclient` to first download files before installing with apt module because the apt module fails to download the files (must be a bug in Ansible 2.6 because the download message is 'OK' but the status code is 'None' and Ansible looks for status code 200) ([#155](https://github.com/cyverse/atmosphere-ansible/pull/155))
 
 ### Fixed
 

--- a/ansible/ansible.cfg.j2
+++ b/ansible/ansible.cfg.j2
@@ -14,19 +14,19 @@
 # note, separating out the ansible inventory into a separate directory
 # since by default the group and host vars use the base path of
 # the hosts file
-hostfile       = {{ ATMOSPHERE_ANSIBLE_DIR }}/ansible/hosts
+inventory      = {{ ATMOSPHERE_ANSIBLE_DIR }}/ansible/hosts
 library        = /usr/share/ansible
 remote_tmp     = $HOME/.ansible/tmp
 pattern        = *
 # set to 3x number of cores
 forks          = 45
 poll_interval  = 15
-sudo_user      = root
+become_user    = root
 #ask_sudo_pass = True
 #ask_pass      = True
 transport      = smart
 remote_port    = 22
-module_lang    = C
+# module_lang    = C
 retry_files_enabled = False
 
 # plays will gather facts by default, which contain information about
@@ -44,7 +44,7 @@ roles_path = {{ ATMOSPHERE_ANSIBLE_DIR }}/ansible/roles
 host_key_checking = False
 
 # change this for alternative sudo implementations
-sudo_exe = sudo
+become_exe = sudo
 
 # what flags to pass to sudo
 #sudo_flags = -H

--- a/ansible/playbooks/instance_actions/unmount_volume.yml
+++ b/ansible/playbooks/instance_actions/unmount_volume.yml
@@ -9,7 +9,7 @@
 
     - fail:
         msg: "Must set src. Pass a value in via `-e` as JSON {{example[0]}}"
-      when: "{{ src is not defined }}"
+      when: src is not defined
 
 - name: Playbook to unmount a volume
   hosts: atmosphere

--- a/ansible/roles/atmo-common/tasks/main.yml
+++ b/ansible/roles/atmo-common/tasks/main.yml
@@ -17,8 +17,9 @@
   when: ansible_distribution == "Ubuntu"
 
 - name: install dependencies
-  action: >
-    {{ ansible_pkg_mgr }} name={{ item }} state=present
+  package:
+    name: '{{ item }}'
+    state: 'present'
   with_items: '{{ PACKAGES }}'
   tags: install
 
@@ -36,7 +37,8 @@
     - timezone
 
 - name: update timezone manually
-  shell: /bin/su {{ item }} -c export TZ={{ TIMEZONE }}
+  become_user: '{{ item }}'
+  shell: 'export TZ={{ TIMEZONE }}'
   with_items:
     - root
     - "{{ ATMOUSERNAME }}"
@@ -134,9 +136,9 @@
 #   situation. we'll allow it due to the benefit. Any failure is ignore,
 #   limiting the risk of affecting deploys.
 - name: checkout the top level git repo for ez
-  git: 
+  git:
     repo: "https://github.com/cyverse/cyverse-ez.git"
-    dest: "/opt/cyverse-ez" 
+    dest: "/opt/cyverse-ez"
     force: yes
   ignore_errors: yes
 

--- a/ansible/roles/atmo-ephemeral-mount/tasks/main.yml
+++ b/ansible/roles/atmo-ephemeral-mount/tasks/main.yml
@@ -20,7 +20,7 @@
   when:
     - 'ephem_stat.stat.islnk is defined'
     - 'ephem_stat.stat.islnk == true'
-    - 'item.device == "{{ ephem_stat.stat.lnk_source }}"'
+    - 'item.device == ephem_stat.stat.lnk_source'
     - 'item.mount != "/mnt"'
   with_items: '{{ ansible_mounts }}'
 

--- a/ansible/roles/atmo-kanki-irodsclient/tasks/main.yml
+++ b/ansible/roles/atmo-kanki-irodsclient/tasks/main.yml
@@ -37,6 +37,7 @@
       get_url:
         dest: '{{ item.dest }}'
         url: '{{ item.url }}'
+        checksum: 'sha1:{{ item.checksum }}'
       with_items: "{{ irods_files }}"
       when: ansible_distribution == "Ubuntu"
 

--- a/ansible/roles/atmo-kanki-irodsclient/tasks/main.yml
+++ b/ansible/roles/atmo-kanki-irodsclient/tasks/main.yml
@@ -33,10 +33,17 @@
       with_items: "{{ irods_files }}"
       when: ansible_distribution == "CentOS"
 
+    - name: Download iRods debs on Ubuntu
+      get_url:
+        dest: '{{ item.dest }}'
+        url: '{{ item.url }}'
+      with_items: "{{ irods_files }}"
+      when: ansible_distribution == "Ubuntu"
+
     - name: Install iRods on Ubuntu
       apt:
         state: present
-        deb: "{{ item }}"
+        deb: "{{ item.dest }}"
       with_items: "{{ irods_files }}"
       when: ansible_distribution == "Ubuntu"
 

--- a/ansible/roles/atmo-kanki-irodsclient/vars/Ubuntu.yml
+++ b/ansible/roles/atmo-kanki-irodsclient/vars/Ubuntu.yml
@@ -12,6 +12,6 @@ dependencies:
   - g++
 
 irods_files:
-  - { url: 'ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-runtime-4.1.9-ubuntu14-x86_64.deb', dest: '/tmp/irods-runtime.deb' }
-  - { url: 'ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-icommands-4.1.9-ubuntu14-x86_64.deb', dest: '/tmp/irods-icommands.deb' }
-  - { url: 'ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-dev-4.1.9-ubuntu14-x86_64.deb', dest: '/tmp/irods-dev.deb' }
+  - { url: 'ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-runtime-4.1.9-ubuntu14-x86_64.deb', dest: '/tmp/irods-runtime.deb', checksum: '0c44062d184150469bf0662ee7aca888796067bc' }
+  - { url: 'ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-icommands-4.1.9-ubuntu14-x86_64.deb', dest: '/tmp/irods-icommands.deb', checksum: '5e10ccc925c7c9de8a48d9e5575e67a2751de7d7' }
+  - { url: 'ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-dev-4.1.9-ubuntu14-x86_64.deb', dest: '/tmp/irods-dev.deb', checksum: '6a46e71bc08c31bfb89ce98ec97b80f874e2a13e' }

--- a/ansible/roles/atmo-kanki-irodsclient/vars/Ubuntu.yml
+++ b/ansible/roles/atmo-kanki-irodsclient/vars/Ubuntu.yml
@@ -12,6 +12,6 @@ dependencies:
   - g++
 
 irods_files:
-  - ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-runtime-4.1.9-ubuntu14-x86_64.deb
-  - ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-icommands-4.1.9-ubuntu14-x86_64.deb
-  - ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-dev-4.1.9-ubuntu14-x86_64.deb
+  - { url: 'ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-runtime-4.1.9-ubuntu14-x86_64.deb', dest: '/tmp/irods-runtime.deb' }
+  - { url: 'ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-icommands-4.1.9-ubuntu14-x86_64.deb', dest: '/tmp/irods-icommands.deb' }
+  - { url: 'ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-dev-4.1.9-ubuntu14-x86_64.deb', dest: '/tmp/irods-dev.deb' }

--- a/ansible/roles/atmo-ntp/tasks/main.yml
+++ b/ansible/roles/atmo-ntp/tasks/main.yml
@@ -12,8 +12,9 @@
     - install
 
 - name: Test curl installed by package manager
-  action: >
-    {{ ansible_pkg_mgr }} name=curl state=present
+  package:
+    name: curl
+    state: present
   register: package_result
   failed_when: package_result.msg is defined and package_result.msg == "No package matching 'curl' is available"
   tags:
@@ -52,15 +53,17 @@
     - time
 
 - name: install ntp prep package(s) -- Ubuntu only
-  shell: >
-    apt-get -qy install {{ NTP_PREP_PACKAGE.name }}
+  apt:
+    name: "{{ NTP_PREP_PACKAGE.name }}"
+    state: present
   tags:
     - install
   when: ansible_distribution == "Ubuntu" and NTP_PREP_PACKAGE is defined and NTP_PREP_PACKAGE.name != ""
 
 - name: install ntp prep package(s) -- Non-Ubuntu using action module
-  action: >
-    {{ ansible_pkg_mgr }} name={{ NTP_PREP_PACKAGE.name }} state={{ NTP_PREP_PACKAGE.state }}
+  package:
+    name: "{{ NTP_PREP_PACKAGE.name }}"
+    state: "{{ NTP_PREP_PACKAGE.state }}"
   tags:
     - install
   when: ansible_distribution != "Ubuntu" and NTP_PREP_PACKAGE is defined and NTP_PREP_PACKAGE != ""

--- a/ansible/roles/atmo-ntp/tasks/main.yml
+++ b/ansible/roles/atmo-ntp/tasks/main.yml
@@ -52,21 +52,13 @@
   tags:
     - time
 
-- name: install ntp prep package(s) -- Ubuntu only
-  apt:
-    name: "{{ NTP_PREP_PACKAGE.name }}"
-    state: present
-  tags:
-    - install
-  when: ansible_distribution == "Ubuntu" and NTP_PREP_PACKAGE is defined and NTP_PREP_PACKAGE.name != ""
-
-- name: install ntp prep package(s) -- Non-Ubuntu using action module
+- name: install ntp prep package(s)
   package:
     name: "{{ NTP_PREP_PACKAGE.name }}"
     state: "{{ NTP_PREP_PACKAGE.state }}"
   tags:
     - install
-  when: ansible_distribution != "Ubuntu" and NTP_PREP_PACKAGE is defined and NTP_PREP_PACKAGE != ""
+  when: NTP_PREP_PACKAGE is defined and NTP_PREP_PACKAGE.name != ""
 
 - name: install ntp package
   action: >

--- a/ansible/roles/atmo-ntp/vars/Ubuntu.yml
+++ b/ansible/roles/atmo-ntp/vars/Ubuntu.yml
@@ -1,10 +1,10 @@
 NTP_PREP_PACKAGE:
   name: libssl1.0.0
-  state: installed
+  state: present
 
 NTP_PACKAGE:
   name: ntp
-  state: installed
+  state: present
 
 NTP_SERVICE: ntp
 

--- a/ansible/roles/atmo-ntp/vars/default.yml
+++ b/ansible/roles/atmo-ntp/vars/default.yml
@@ -1,6 +1,6 @@
 NTP_PACKAGE:
   name: ntp
-  state: installed
+  state: present
 
 NTP_SERVICE: ntpd
 

--- a/ansible/roles/atmo-pre-setup/tasks/Ubuntu.yml
+++ b/ansible/roles/atmo-pre-setup/tasks/Ubuntu.yml
@@ -6,11 +6,11 @@
 
 - name: if x64 found, remove x64 architecture
   shell: dpkg --remove-architecture x64
-  when: x64_arch_exists|success
+  when: x64_arch_exists is success
 
 - name: if x64 found, add amd64
   shell: dpkg --add-architecture amd64
-  when: x64_arch_exists|success
+  when: x64_arch_exists is success
 
 # - wait_for: path=/var/lib/apt/lists/lock state=absent
   # retries: 6

--- a/ansible/roles/atmo-pre-setup/tasks/main.yml
+++ b/ansible/roles/atmo-pre-setup/tasks/main.yml
@@ -6,14 +6,15 @@
 
 - name: if x64 found, remove x64 architecture
   shell: dpkg --remove-architecture x64
-  when: ansible_distribution == "Ubuntu" and x64_arch_exists|success
+  when: ansible_distribution == "Ubuntu" and x64_arch_exists is success
 
 - name: if x64 found, add amd64
   shell: dpkg --add-architecture amd64
-  when: ansible_distribution == "Ubuntu" and x64_arch_exists|success 
+  when: ansible_distribution == "Ubuntu" and x64_arch_exists is success
 
 - name: apt-get update
-  shell: apt-get update 
+  apt:
+    update_cache: yes
   when: ansible_distribution == "Ubuntu"
   failed_when: False
   tags: update
@@ -31,7 +32,8 @@
   - meta: flush_handlers
 
   - name: yum check-update
-    shell: yum check-update 
+    yum:
+      update_cache: yes
     failed_when: False
     tags: update
 

--- a/ansible/roles/atmo-setup-user/tasks/main.yml
+++ b/ansible/roles/atmo-setup-user/tasks/main.yml
@@ -61,9 +61,8 @@
   lineinfile: dest=/etc/group regexp='^({{ ADD_TO_GROUP.GROUP }}:x:100:)(.*)' line="\1{{ item }},\2" state=present backrefs=yes
   with_items:
     - '{{ ADD_TO_GROUP.LIST_OF_USERS }}'
-  when: 'user_not_present.rc == 1'
   tags: debug-ssh
-  when: ADD_TO_GROUP is defined
+  when: ADD_TO_GROUP is defined and user_not_present.rc == 1
 
 - name: add ATMOUSERNAME to users group
   lineinfile: dest=/etc/group regexp='^(users:x:100:)(.*)' line="\1{{ ATMOUSERNAME }},\2" state=present backrefs=yes

--- a/ansible/roles/atmo-ssh-setup/tasks/ssh-setup.yml
+++ b/ansible/roles/atmo-ssh-setup/tasks/ssh-setup.yml
@@ -5,7 +5,7 @@
 
 - name: Gather OS-specific variables
   include_vars: "{{ item.var }}"
-  when: "{{ item.condition }}"
+  when: "item.condition"
   with_items:
     - { var: 'Ubuntu.yml', condition: ansible_distribution == "Ubuntu" }
     - { var: 'CentOS.yml', condition: ansible_distribution == "CentOS" }

--- a/ansible/roles/check_networking/tasks/main.yml
+++ b/ansible/roles/check_networking/tasks/main.yml
@@ -1,4 +1,4 @@
---- 
+---
 - name: get atmo vm ip address
   set_fact:
     vm_ip: "{{ ansible_host }}"
@@ -32,7 +32,7 @@
       command ssh {{ SSH_OPTIONS}} -p {{ ansible_port }} centos@{{ vm_ip }} 'echo hello' | grep 'hello'
   register: centos_remote_user
   ignore_errors: yes
-  when: default_remote_user|failed
+  when: default_remote_user is failed
   failed_when: False
   async: "{{ SSH_TIMEOUT }}"
   poll: 1
@@ -45,16 +45,16 @@
     command ssh {{ SSH_OPTIONS }} -p {{ ansible_port }} ubuntu@{{ vm_ip }} 'echo hello' | grep 'hello'
   register: ubuntu_remote_user
   ignore_errors: yes
-  when: default_remote_user|failed and centos_remote_user|failed
+  when: default_remote_user is failed and centos_remote_user is failed
   failed_when: False
   async: "{{ SSH_TIMEOUT }}"
   poll: 1
 
 # - debug: msg="root output is {{ default_remote_user.stdout }} and err is {{ default_remote_user.stderr }}"
-# 
+#
 # - debug: msg="centos output is {{ centos_remote_user.stdout }} and err is {{ centos_remote_user.stderr }}"
 #   when: default_remote_user|failed
-# 
+#
 # - debug: msg="ubuntu output is {{ ubuntu_remote_user.stdout }} and err is {{ ubuntu_remote_user.stderr }}"
 #   when: default_remote_user|failed and centos_remote_user|failed
 

--- a/ansible/roles/ldap/tasks/main.yml
+++ b/ansible/roles/ldap/tasks/main.yml
@@ -119,7 +119,7 @@
     - authconfig
 
 - name: template password-auth
-  template: src={{ item }} dest=/etc/pam.d/password-auth backup=yes
+  template: src={{ item }} dest=/etc/pam.d/password-auth backup=yes follow=yes
   with_first_found:
     - files:
       - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.password-auth.j2"

--- a/ansible/roles/ldap/tasks/main.yml
+++ b/ansible/roles/ldap/tasks/main.yml
@@ -19,8 +19,9 @@
     - vars
 
 - name: install ldap packages
-  action: >
-    {{ ansible_pkg_mgr }} name={{ item }} state={{ LDAP_PACKAGES.state }}
+  package:
+    name: '{{ item }}'
+    state: '{{ LDAP_PACKAGES.state }}'
   with_items: "{{ LDAP_PACKAGES.packages }}"
   tags:
     - install
@@ -161,7 +162,9 @@
     - restart-oddjobd
 
 - name: restart services again just to be safe for CentOS 6
-  shell: service {{ item }} restart
+  service:
+    name: '{{ item }}'
+    state: 'restarted'
   with_items:
     - "{{ LDAP_SERVICE }}"
     - messagebus
@@ -169,7 +172,9 @@
   when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "6"
 
 - name: restart services again just to be safe for CentOS 7
-  shell: systemctl restart {{ item }}
+  service:
+    name: '{{ item }}'
+    state: 'restarted'
   with_items:
     - "{{ LDAP_SERVICE }}"
     - messagebus
@@ -233,19 +238,19 @@
     - reload-dbus
 
 - name: restart nscd and nslcd services again just to be safe
-  shell: service {{ item }} restart
+  service:
+    name: '{{ item }}'
+    state: 'restarted'
   with_items:
     - nscd
     - nslcd
   when: ansible_distribution == "Ubuntu"
 
-- name: restart dbus again just to be safe for pre-Ubuntu 16.04
-  shell: service dbus restart
-  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int < 16
-
-- name: reload dbus again just to be safe for Ubuntu 16.04 and later
-  shell: systemctl reload dbus
-  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 16
+- name: restart dbus again just to be safe for Ubuntu
+  service:
+    name: 'dbus'
+    state: 'reloaded'
+  when: ansible_distribution == "Ubuntu"
 
 - name: loop until ldap connection is made, fails if it can't
   command: id {{ TEST_LDAP_USER }}


### PR DESCRIPTION
## Description

In order for Atmosphere-Ansible to be compatible with the latest Ansible (2.6.1), quite a few changes were required.

Deprecation fixes in `ansible.cfg`:
- `hostfile` changed to `inventory`
- instances of `sudo` changed to `become` (`sudo_user`, `sudo_exe`)
- `module_lang` deprecated

Deprecation fixes in roles:
- uses of `{{ var }}` in `when:` statements had to be changed to just `var`
- in packaging modules, `state: present` is used instead of `state: installed`
- replace instances of `system` or `systemctl` commands in shell modules with `service` module
- conditional tests using Jinja filters like `result|success` replaced with `result is success`
- specify `follow=yes` in template module that writes to a symlink because in Ansible 2.4 the default changed to `no`.

Bugs:
- in `atmo-kanki-irodsclient` role, the `apt` module was used with ftp URLs to download and install `.deb` files. This task began to fail with newer versions of Ansible, and with further investigation it looked like the download was succeeding because the error message would include `OK (12345 bytes downloaded)` where the number of bytes was the exact size of the file, so it is due to a bug in Ansible. A [recent commit](https://github.com/ansible/ansible/commit/86a63cf) added a check for http status codes to see if the download succeeded, but the status was `None` in this case, probably due to the fact that it is ftp now https (you can compare the check in that commit with the similar one used in the `get_url` module [here](https://github.com/ansible/ansible/blob/8606fb33f0e8954b588eaecec2d99b4a120fd4ad/lib/ansible/modules/net_tools/basics/get_url.py#L332)). I deal with this bug by downloading the files first, then installing. Maybe I should submit a bug fix to Ansible 🤔 

Related PR: Atmosphere [PR #635](https://github.com/cyverse/atmosphere/pull/635)