### PR TITLE
Restart network service to renew DHCP lease

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/atmosphere-ansible/compare/v33-0...HEAD) - YYYY-MM-DD
+### Fixed
+  - Fixed task that runs `dhclient` for CentOS so that it does not fail if the
+    process is already running
+    ([#156](https://github.com/cyverse/atmosphere-ansible/pull/156))
+
 ## [v33-0](https://github.com/cyverse/atmosphere-ansible/compare/...v33-0) - 2018-08-08
 ### Added
   - On CentOS, the dhclient.d script `ntp.sh` is configured to remove previously

--- a/ansible/roles/atmo-ntp/tasks/main.yml
+++ b/ansible/roles/atmo-ntp/tasks/main.yml
@@ -113,7 +113,9 @@
   when: 'ansible_distribution == "CentOS"'
 
 - name: 'Renew DHCP lease for CentOS'
-  command: 'dhclient'
+  service:
+    name: 'network'
+    state: 'restarted'
   when: 'ansible_distribution == "CentOS"'
 
 - name: start ntp service


### PR DESCRIPTION
## Description

Problem: The task that runs dhclient for CentOS fails after the first successful attempt because the dhclient process is already running.
Instead of force killing the process with pkill, restarting the network service will properly stop and start dhclient.

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [x] Reviewed and approved by at least one other contributor.