### PR TITLE
Improve iRods install tasks and update URLs to secure HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
     the download message is 'OK' but the status code is 'None' and Ansible
     looks for status code 200)
     ([#155](https://github.com/cyverse/atmosphere-ansible/pull/155))
+  - Changed `atmo-kanki-irodsclient` and `irods-icommands` roles to download packages from the new iRods HTTPS URLs ([#161](https://github.com/cyverse/atmosphere-ansible/pull/161))  
 
 ## [v33-0](https://github.com/cyverse/atmosphere-ansible/compare/...v33-0) - 2018-08-08
 ### Added

--- a/ansible/roles/atmo-kanki-irodsclient/tasks/main.yml
+++ b/ansible/roles/atmo-kanki-irodsclient/tasks/main.yml
@@ -33,18 +33,10 @@
       with_items: "{{ irods_files }}"
       when: ansible_distribution == "CentOS"
 
-    - name: Download iRods debs on Ubuntu
-      get_url:
-        dest: '{{ item.dest }}'
-        url: '{{ item.url }}'
-        checksum: 'sha1:{{ item.checksum }}'
-      with_items: "{{ irods_files }}"
-      when: ansible_distribution == "Ubuntu"
-
     - name: Install iRods on Ubuntu
       apt:
         state: present
-        deb: "{{ item.dest }}"
+        deb: "{{ item }}"
       with_items: "{{ irods_files }}"
       when: ansible_distribution == "Ubuntu"
 

--- a/ansible/roles/atmo-kanki-irodsclient/vars/CentOS-7.yml
+++ b/ansible/roles/atmo-kanki-irodsclient/vars/CentOS-7.yml
@@ -1,0 +1,16 @@
+---
+
+xsession_path: /usr/bin/xinit
+xterm_path: /usr/bin/Xorg
+
+dependencies:
+  - epel-release
+  - openssl-devel
+  - libcurl-devel
+  - qt5-qtsvg-devel
+  - qt5-qtbase-devel
+
+irods_files:
+  - https://files.renci.org/pub/irods/releases/4.1.9/centos7/irods-dev-4.1.9-centos7-x86_64.rpm
+  - https://files.renci.org/pub/irods/releases/4.1.9/centos7/irods-icommands-4.1.9-centos7-x86_64.rpm
+  - https://files.renci.org/pub/irods/releases/4.1.9/centos7/irods-runtime-4.1.9-centos7-x86_64.rpm

--- a/ansible/roles/atmo-kanki-irodsclient/vars/CentOS.yml
+++ b/ansible/roles/atmo-kanki-irodsclient/vars/CentOS.yml
@@ -11,6 +11,6 @@ dependencies:
   - qt5-qtbase-devel
 
 irods_files:
-  - ftp://ftp.renci.org/pub/irods/releases/4.1.9/centos6/irods-runtime-4.1.9-centos6-x86_64.rpm
-  - ftp://ftp.renci.org/pub/irods/releases/4.1.9/centos6/irods-icommands-4.1.9-centos6-x86_64.rpm
-  - ftp://ftp.renci.org/pub/irods/releases/4.1.9/centos6/irods-dev-4.1.9-centos6-x86_64.rpm
+  - https://files.renci.org/pub/irods/releases/4.1.9/centos6/irods-dev-4.1.9-centos6-x86_64.rpm
+  - https://files.renci.org/pub/irods/releases/4.1.9/centos6/irods-icommands-4.1.9-centos6-x86_64.rpm
+  - https://files.renci.org/pub/irods/releases/4.1.9/centos6/irods-runtime-4.1.9-centos6-x86_64.rpm

--- a/ansible/roles/atmo-kanki-irodsclient/vars/Ubuntu.yml
+++ b/ansible/roles/atmo-kanki-irodsclient/vars/Ubuntu.yml
@@ -12,6 +12,6 @@ dependencies:
   - g++
 
 irods_files:
-  - { url: 'ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-runtime-4.1.9-ubuntu14-x86_64.deb', dest: '/tmp/irods-runtime.deb', checksum: '0c44062d184150469bf0662ee7aca888796067bc' }
-  - { url: 'ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-icommands-4.1.9-ubuntu14-x86_64.deb', dest: '/tmp/irods-icommands.deb', checksum: '5e10ccc925c7c9de8a48d9e5575e67a2751de7d7' }
-  - { url: 'ftp://ftp.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-dev-4.1.9-ubuntu14-x86_64.deb', dest: '/tmp/irods-dev.deb', checksum: '6a46e71bc08c31bfb89ce98ec97b80f874e2a13e' }
+  - https://files.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-dev-4.1.9-ubuntu14-x86_64.deb
+  - https://files.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-icommands-4.1.9-ubuntu14-x86_64.deb
+  - https://files.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-runtime-4.1.9-ubuntu14-x86_64.deb

--- a/ansible/roles/irods-icommands/tasks/main.yml
+++ b/ansible/roles/irods-icommands/tasks/main.yml
@@ -110,14 +110,6 @@
   when: not (ansible_distribution == "CentOS" and ansible_distribution_major_version < '6')
   tags: icommands-setup
 
-- name: Download installation package for non-CentOS 5
-  get_url:
-    url: "{{ ICOMMANDS_URL }}"
-    dest: /tmp/icommands-pkg.rpm
-  changed_when: false
-  when: not (ansible_distribution == "CentOS" and ansible_distribution_major_version < '6')
-  tags: icommands-setup
-
 - name: Uninstall existing iCommands for Ubuntu
   apt:
     name: irods-icommands
@@ -135,14 +127,15 @@
 
 - name: Install iCommands for Ubuntu
   apt:
-    deb: /tmp/icommands-pkg.rpm
+    state: 'present'
+    deb: '{{ ICOMMANDS_URL }}'
   when: ansible_distribution == "Ubuntu"
   tags: icommands-setup
 
-- name: Install iCommands for CentOS 6 and 7
+- name: Install iCommands for CentOS
   yum:
-    name: /tmp/icommands-pkg.rpm
     state: present
+    name: '{{ ICOMMANDS_URL }}'
   when: (ansible_distribution == "CentOS" and ansible_distribution_major_version > "5")
   tags: icommands-setup
 

--- a/ansible/roles/irods-icommands/vars/CentOS-6.yml
+++ b/ansible/roles/irods-icommands/vars/CentOS-6.yml
@@ -1,9 +1,0 @@
-IRODSFS_EXECUTABLE: irodsFs_v32.rhel5.x86_64
-IRODSFS_DESTINATION: /usr/local/bin/irodsFs.x86_64
-IRODSFS_LINK: /usr/local/bin/irodsFs
-
-ICOMMANDS_TAR: icommands_v331.centos.x86_64.tar.bz2
-ICOMMANDS_DESTINATION: /opt
-BIN_PATH: /usr/local/bin
-
-ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-cv-64bit-centos6.rpm

--- a/ansible/roles/irods-icommands/vars/CentOS-7.yml
+++ b/ansible/roles/irods-icommands/vars/CentOS-7.yml
@@ -6,4 +6,4 @@ ICOMMANDS_TAR: icommands_v331.centos.x86_64.tar.bz2
 ICOMMANDS_DESTINATION: /opt
 BIN_PATH: /usr/local/bin
 
-ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-cv-64bit-centos7.rpm
+ICOMMANDS_URL: https://files.renci.org/pub/irods/releases/4.1.9/centos7/irods-icommands-4.1.9-centos7-x86_64.rpm

--- a/ansible/roles/irods-icommands/vars/CentOS.yml
+++ b/ansible/roles/irods-icommands/vars/CentOS.yml
@@ -6,4 +6,4 @@ ICOMMANDS_TAR: icommands_v331.centos.x86_64.tar.bz2
 ICOMMANDS_DESTINATION: /opt
 BIN_PATH: /usr/local/bin
 
-ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-cv-64bit-centos6.rpm
+ICOMMANDS_URL: https://files.renci.org/pub/irods/releases/4.1.9/centos6/irods-icommands-4.1.9-centos6-x86_64.rpm

--- a/ansible/roles/irods-icommands/vars/Ubuntu.yml
+++ b/ansible/roles/irods-icommands/vars/Ubuntu.yml
@@ -6,4 +6,4 @@ ICOMMANDS_TAR: icommands_v331.ubuntu.x86_64.tar.bz2
 ICOMMANDS_DESTINATION: /opt
 BIN_PATH: /usr/local/bin
 
-ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-cv-64bit-ubuntu-14.deb
+ICOMMANDS_URL: https://files.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-icommands-4.1.9-ubuntu14-x86_64.deb


### PR DESCRIPTION
## Description

This PR updates the download URLs in `kanki-irods-client` and `irods-icommands` to use HTTPS, fixing issue #160.

Tested on:
- [x] Ubuntu 14
- [x] Ubuntu 16
- [x] CentOS 6
- [x] CentOS 7

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [x] Add an entry in the changelog
- [ ] Documentation created/updated (include links)
- [ ] Reviewed and approved by at least one other contributor.
- [ ] New variables contributed to atmosphere/Clank