### PR TITLE
Fix instances that were failing to get networking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
   - Fixed task that runs `dhclient` for CentOS so that it does not fail if the
     process is already running
     ([#156](https://github.com/cyverse/atmosphere-ansible/pull/156))
+    ([#163](https://github.com/cyverse/atmosphere-ansible/pull/163))
 
 ## [v33-0](https://github.com/cyverse/atmosphere-ansible/compare/...v33-0) - 2018-08-08
 ### Added

--- a/ansible/roles/atmo-ntp/tasks/main.yml
+++ b/ansible/roles/atmo-ntp/tasks/main.yml
@@ -108,10 +108,9 @@
   when: 'ansible_distribution == "CentOS"'
 
 - name: 'Renew DHCP lease for CentOS'
-  service:
-    name: 'network'
-    state: 'restarted'
+  command: "dhclient"
   when: 'ansible_distribution == "CentOS"'
+  ignore_errors: yes
 
 - name: start ntp service
   action: >


### PR DESCRIPTION
## Description
### Problem
Restarting networking during a system's boot would interfere with the system
getting networking.

### Solution
Don't perform a service network restart

We were performing a restart because it seemed like a reliable to ensure a new
dhcp lease. We're reverting to our original behavior of running dhclient, but
this time we don't fail if dhclient is already running/getting a lease

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [x] Reviewed and approved by at least one other contributor.