### PR TITLE
Fix incorrect condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/atmosphere-ansible/compare/v34-0...HEAD) - YYYY-MM-DD
+### Fixed
+  - Fixed incorrect condition resulting in Ubuntu 14 failure to restart
+    service ([#165](https://github.com/cyverse/atmosphere-ansible/pull/165))
+
 ## [v34-0](https://github.com/cyverse/atmosphere-ansible/compare/v33-0...v34-0) - 2018-09-17
 ### Changed
   - Renamed Subspace variables to use Ansible keyword instead of Subspace

--- a/ansible/roles/atmo-ssh-setup/tasks/ssh-setup.yml
+++ b/ansible/roles/atmo-ssh-setup/tasks/ssh-setup.yml
@@ -4,11 +4,7 @@
   setup:
 
 - name: Gather OS-specific variables
-  include_vars: "{{ item.var }}"
-  when: "item.condition"
-  with_items:
-    - { var: 'Ubuntu.yml', condition: ansible_distribution == "Ubuntu" }
-    - { var: 'CentOS.yml', condition: ansible_distribution == "CentOS" }
+  include_vars: "{{ ansible_distribution }}.yml"
 
 - name: Make sure ssh directory exists with correct permissions
   file:


### PR DESCRIPTION
## Description
### Problem
Ansible would fail on ubuntu 14 with: Could not find the requested service sshd: host

### Solution
The error wasn't super clear, but the issue was that we were retrying to
restart `sshd` on ubuntu systems which is wrong. It should be retrying to
restart `ssh`. It turned out CentOS variables we're being loaded
everytime even for ubuntu systems. This is because the when condition was
always true.

In the below task: item.condition expands to the string: "ansible_distribution == ...".
In the when clause we're then asking if that string is truthy, which it always is.

    - name: Gather OS-specific variables
      include_vars: "{{ item.var }}"
      when: "item.condition"
      with_items:
        - { var: 'Ubuntu.yml', condition: ansible_distribution == "Ubuntu" }
        - { var: 'CentOS.yml', condition: ansible_distribution == "CentOS" }

You might expect item.condition to have been true or false, but in yaml
everything is a string unless your in a context where values are evaluated
like between double brackets or in a when.

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [x] Reviewed and approved by at least one other contributor.