### PR TITLE
Change iRods iCommands URLs back to custom CyVerse version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/atmosphere-ansible/compare/v34-1...HEAD) - YYYY-MM-DD
+### Fixed
+  - Fix slow iRods Fuse performance
+    ([#168](https://github.com/cyverse/atmosphere-ansible/pull/168))
+
 ## [v34-1](https://github.com/cyverse/atmosphere-ansible/compare/v34-0...v34-1) - 2018-09-18
 ### Fixed
   - Fixed incorrect condition resulting in Ubuntu 14 failure to restart

--- a/ansible/roles/irods-icommands/vars/CentOS-7.yml
+++ b/ansible/roles/irods-icommands/vars/CentOS-7.yml
@@ -6,4 +6,4 @@ ICOMMANDS_TAR: icommands_v331.centos.x86_64.tar.bz2
 ICOMMANDS_DESTINATION: /opt
 BIN_PATH: /usr/local/bin
 
-ICOMMANDS_URL: https://files.renci.org/pub/irods/releases/4.1.9/centos7/irods-icommands-4.1.9-centos7-x86_64.rpm
+ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-cv-64bit-centos7.rpm

--- a/ansible/roles/irods-icommands/vars/CentOS.yml
+++ b/ansible/roles/irods-icommands/vars/CentOS.yml
@@ -6,4 +6,4 @@ ICOMMANDS_TAR: icommands_v331.centos.x86_64.tar.bz2
 ICOMMANDS_DESTINATION: /opt
 BIN_PATH: /usr/local/bin
 
-ICOMMANDS_URL: https://files.renci.org/pub/irods/releases/4.1.9/centos6/irods-icommands-4.1.9-centos6-x86_64.rpm
+ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-cv-64bit-centos6.rpm

--- a/ansible/roles/irods-icommands/vars/Ubuntu.yml
+++ b/ansible/roles/irods-icommands/vars/Ubuntu.yml
@@ -6,4 +6,4 @@ ICOMMANDS_TAR: icommands_v331.ubuntu.x86_64.tar.bz2
 ICOMMANDS_DESTINATION: /opt
 BIN_PATH: /usr/local/bin
 
-ICOMMANDS_URL: https://files.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-icommands-4.1.9-ubuntu14-x86_64.deb
+ICOMMANDS_URL: https://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-cv-64bit-ubuntu-14.deb


### PR DESCRIPTION
## Description

Problem: [This commit](https://github.com/cyverse/atmosphere-ansible/commit/0741cffeb156d66df26ad7b1243086c89e7fea65#diff-7f4e8e482785f360de90be212be73cb7) replaced iRods iCommands URLs with the ones provided by iRods, but CyVerse was using a custom version with improvements to iRods Fuse.

This PR simply reverts the changes and uses the custom URLs

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [x] Add an entry in the changelog
- [ ] Documentation created/updated (include links)
- [x] Reviewed and approved by at least one other contributor.
- [ ] New variables contributed to atmosphere/Clank