### PR TITLE
ATMO-2160: Install cloud-init as part of the imaging process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Fixed
   - Fix slow iRods Fuse performance
     ([#168](https://github.com/cyverse/atmosphere-ansible/pull/168))
+  - Install cloud-init as part of the imaging process ([#169](https://github.com/cyverse/atmosphere-ansible/pull/169))
 
 ## [v34-1](https://github.com/cyverse/atmosphere-ansible/compare/v34-0...v34-1) - 2018-09-18
 ### Fixed

--- a/ansible/playbooks/imaging/prepare_instance_snapshot.yml
+++ b/ansible/playbooks/imaging/prepare_instance_snapshot.yml
@@ -3,11 +3,30 @@
 - name: Sync and freeze instance (Helpful as part of the imaging process)
   hosts: all
   tasks:
+    - name: Ensure cloud-init is installed with default config on Ubuntu 18+
+      block:
+      - name: Uninstall cloud-init
+        package:
+          name: '{{ item }}'
+          state: 'absent'
+        loop:
+          - 'cloud-init'
+          - 'cloud-utils'
+
+      - name: Delete cloud-init files
+        file:
+          path: '{{ item }}'
+          state: 'absent'
+        loop:
+          - '/etc/cloud'
+          - '/var/lib/cloud'
+      when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version >= '18'
+
     - name: Install cloud-init and cloud-utils
       package:
         name: '{{ item }}'
         state: 'present'
-      with_items:
+      loop:
         - 'cloud-init'
         - 'cloud-utils'
 

--- a/ansible/playbooks/imaging/prepare_instance_snapshot.yml
+++ b/ansible/playbooks/imaging/prepare_instance_snapshot.yml
@@ -3,6 +3,14 @@
 - name: Sync and freeze instance (Helpful as part of the imaging process)
   hosts: all
   tasks:
+    - name: Install cloud-init and cloud-utils
+      package:
+        name: '{{ item }}'
+        state: 'present'
+      with_items:
+        - 'cloud-init'
+        - 'cloud-utils'
+
     - name: Run sync command
       command: sync
 


### PR DESCRIPTION
## Description

This change simply installs cloud-init as part of the imaging preparation playbook. This is required for [Chromogenic PR #14](https://github.com/cyverse/chromogenic/pull/14) because virt-sysprep is unable to use networking to install it on the image. The solution is to install it on the instance while it has internet access.

Simply reinstalling cloud-init did not fix the issue on Ubuntu 18.04. The new image would fail to boot successfully because networking was not correctly setup. [The solution](https://serverfault.com/questions/918911/ubuntu-18-04-network-after-cloud-init-removal) for this was to delete the `/etc/cloud` directory before reinstalling cloud-init. However, this causes problems for instances that already have cloud-init installed because the directory will be deleted and never recreated. Therefore the solution is to uninstall cloud-init and delete directories before reinstalling only on Ubuntu 18+.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [x] Add an entry in the changelog
- [ ] Documentation created/updated (include links)
- [ ] Reviewed and approved by at least one other contributor.
- [ ] New variables contributed to atmosphere/Clank
