### PR TITLE
Disable Gateone when using Guacamole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
     ([#168](https://github.com/cyverse/atmosphere-ansible/pull/168))
   - changed https to http for irods-icommands packages in vars
 
+### Changed
+  - Only use Gateone if Guacamole is disabled
+    ([#170](https://github.com/cyverse/atmosphere-ansible/pull/170))
+
 ## [v34-1](https://github.com/cyverse/atmosphere-ansible/compare/v34-0...v34-1) - 2018-09-18
 ### Fixed
   - Fixed incorrect condition resulting in Ubuntu 14 failure to restart

--- a/ansible/playbooks/instance_deploy/41_shell_access.yml
+++ b/ansible/playbooks/instance_deploy/41_shell_access.yml
@@ -9,7 +9,7 @@
     EXTERNAL_HOST: "shell"
     USERNAME: "{{ ATMOUSERNAME }}"
   roles:
-    - sshkey-host-access
+    - { role: "sshkey-host-access", when: (SETUP_GUACAMOLE | default(true)) == false }
   tasks:
     # Gateone reads this file in the gatone user ssh directory, and uses each
     # identity found there when it tries to open an SSH connection from the
@@ -23,6 +23,7 @@
         owner: "{{ EXTERNAL_HOST_KEY_OWNER }}"
         group: "{{ EXTERNAL_HOST_KEY_GROUP }}"
       delegate_to: "{{ EXTERNAL_HOST }}"
+      when: (SETUP_GUACAMOLE | default(true)) == false
 
 - name: Enable ssh access from guac_server host into user vm
   hosts: atmosphere
@@ -34,4 +35,4 @@
     EXTERNAL_HOST: "guac_server"
     USERNAME: "{{ ATMOUSERNAME }}"
   roles:
-    - { role: "sshkey-host-access", when: (SETUP_GUACAMOLE | default(false)) == true }
+    - { role: "sshkey-host-access", when: (SETUP_GUACAMOLE | default(true)) == true }


### PR DESCRIPTION
## Description

Since we are planning to get rid of Gateone for shell access, the play now will only run if Guacamole is not enabled. Similar to [Troposphere PR #812](https://github.com/cyverse/troposphere/pull/812) the two are mutually exclusive. Also, SETUP_GUACAMOLE now defaults to true

tested on Atmobeta and it works

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [ ] Reviewed and approved by at least one other contributor.
