### PR TITLE
WIP: Use separate container for Celery and Redis

### DIFF
--- a/ansible/ansible.cfg.j2
+++ b/ansible/ansible.cfg.j2
@@ -171,6 +171,7 @@ cow_selection = {{ ANSIBLE_COW_SELECTION }}
 # current IP information.
 
 fact_caching = {{ ANSIBLE_FACT_CACHE_BACKEND }}
+fact_caching_connection = {{ ANSIBLE_REDIS_HOST }}:6379
 # 24 hours of fact caching
 fact_caching_timeout = {{ ANSIBLE_FACT_CACHE_TIMEOUT }}
 

--- a/variables.ini.dist
+++ b/variables.ini.dist
@@ -4,6 +4,7 @@ ATMOSPHERE_ANSIBLE_LOG_DIR = ; /opt/dev/atmosphere-ansible/logs
 
 [ansible.cfg]
 ANSIBLE_FACT_CACHE_BACKEND = ; redis or jsonfile
+ANSIBLE_REDIS_HOST = ;
 ANSIBLE_FACT_CACHE_TIMEOUT = ; Timeout in seconds (14400 == 4 hours)
 ANSIBLE_MANAGED_STR = ; Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}
 ANSIBLE_SSH_TIMEOUT = ; 10
@@ -12,3 +13,4 @@ SUBSPACE_PLUGINS_DIR = ; /opt/env/atmo/lib/python2.7/site-packages/subspace/plug
 SUBSPACE_CALLBACK_WHITELIST = ; play_logger
 SUBSPACE_NO_COWS = ; 1 or 0 , 0 = Cows and 1 = No Cows
 SUBSPACE_COW_SELECTION = ; default (NOTE: Only if NO_COWS == 0)
+


### PR DESCRIPTION
## Description

In order to use Celery outside of the Atmosphere container, Redis is also outside the container. This PR adds variables so that Atmosphere-Ansible can connect to this redis host.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Add an entry in the changelog
- [ ] Documentation created/updated (include links)
- [ ] Reviewed and approved by at least one other contributor.
