### PR TITLE
updated packages for irods-icommnads and added a safe way to fail, in…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
     ([#170](https://github.com/cyverse/atmosphere-ansible/pull/170))
   - Remove FUSE and irodsFs
     ([#172](https://github.com/cyverse/atmosphere-ansible/pull/172))
+  - Removed AWS links for irods-commands packages; now reference renci
+  - Ignore failure of package install in kanki ansible package
 
 ## [v34-1](https://github.com/cyverse/atmosphere-ansible/compare/v34-0...v34-1) - 2018-09-18
 ### Fixed

--- a/ansible/roles/atmo-kanki-irodsclient/tasks/main.yml
+++ b/ansible/roles/atmo-kanki-irodsclient/tasks/main.yml
@@ -32,6 +32,7 @@
         pkg: "{{ item }}"
       with_items: "{{ irods_files }}"
       when: ansible_distribution == "CentOS"
+      ignore_errors: True
 
     - name: Install iRods on Ubuntu
       apt:
@@ -39,6 +40,7 @@
         deb: "{{ item }}"
       with_items: "{{ irods_files }}"
       when: ansible_distribution == "Ubuntu"
+      ignore_errors: True
 
     - name: Create ~/.irods directory
       file:

--- a/ansible/roles/atmo-kanki-irodsclient/vars/CentOS-7.yml
+++ b/ansible/roles/atmo-kanki-irodsclient/vars/CentOS-7.yml
@@ -11,6 +11,5 @@ dependencies:
   - qt5-qtbase-devel
 
 irods_files:
-  - https://files.renci.org/pub/irods/releases/4.1.9/centos7/irods-dev-4.1.9-centos7-x86_64.rpm
-  - https://files.renci.org/pub/irods/releases/4.1.9/centos7/irods-icommands-4.1.9-centos7-x86_64.rpm
-  - https://files.renci.org/pub/irods/releases/4.1.9/centos7/irods-runtime-4.1.9-centos7-x86_64.rpm
+  - https://files.renci.org/pub/irods/releases/4.1.11/centos7/irods-dev-4.1.11-centos7-x86_64.rpm
+  - https://files.renci.org/pub/irods/releases/4.1.11/centos7/irods-runtime-4.1.11-centos7-x86_64.rpm

--- a/ansible/roles/atmo-kanki-irodsclient/vars/CentOS.yml
+++ b/ansible/roles/atmo-kanki-irodsclient/vars/CentOS.yml
@@ -11,6 +11,5 @@ dependencies:
   - qt5-qtbase-devel
 
 irods_files:
-  - https://files.renci.org/pub/irods/releases/4.1.9/centos6/irods-dev-4.1.9-centos6-x86_64.rpm
-  - https://files.renci.org/pub/irods/releases/4.1.9/centos6/irods-icommands-4.1.9-centos6-x86_64.rpm
-  - https://files.renci.org/pub/irods/releases/4.1.9/centos6/irods-runtime-4.1.9-centos6-x86_64.rpm
+  - https://files.renci.org/pub/irods/releases/4.1.11/centos6/irods-dev-4.1.11-centos6-x86_64.rpm
+  - https://files.renci.org/pub/irods/releases/4.1.11/centos6/irods-runtime-4.1.11-centos6-x86_64.rpm

--- a/ansible/roles/atmo-kanki-irodsclient/vars/Ubuntu.yml
+++ b/ansible/roles/atmo-kanki-irodsclient/vars/Ubuntu.yml
@@ -12,6 +12,5 @@ dependencies:
   - g++
 
 irods_files:
-  - https://files.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-dev-4.1.9-ubuntu14-x86_64.deb
-  - https://files.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-icommands-4.1.9-ubuntu14-x86_64.deb
-  - https://files.renci.org/pub/irods/releases/4.1.9/ubuntu14/irods-runtime-4.1.9-ubuntu14-x86_64.deb
+  - https://files.renci.org/pub/irods/releases/4.1.11/ubuntu14/irods-dev-4.1.11-ubuntu14-x86_64.deb
+  - https://files.renci.org/pub/irods/releases/4.1.11/ubuntu14/irods-runtime-4.1.11-ubuntu14-x86_64.deb

--- a/ansible/roles/irods-icommands/vars/CentOS-7.yml
+++ b/ansible/roles/irods-icommands/vars/CentOS-7.yml
@@ -6,4 +6,4 @@ ICOMMANDS_TAR: icommands_v331.centos.x86_64.tar.bz2
 ICOMMANDS_DESTINATION: /opt
 BIN_PATH: /usr/local/bin
 
-ICOMMANDS_URL: http://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-cv-64bit-centos7.rpm
+ICOMMANDS_URL: https://files.renci.org/pub/irods/releases/4.1.11/centos7/irods-icommands-4.1.11-centos7-x86_64.rpm

--- a/ansible/roles/irods-icommands/vars/CentOS.yml
+++ b/ansible/roles/irods-icommands/vars/CentOS.yml
@@ -6,4 +6,4 @@ ICOMMANDS_TAR: icommands_v331.centos.x86_64.tar.bz2
 ICOMMANDS_DESTINATION: /opt
 BIN_PATH: /usr/local/bin
 
-ICOMMANDS_URL: http://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-cv-64bit-centos6.rpm
+ICOMMANDS_URL: https://files.renci.org/pub/irods/releases/4.1.11/centos6/irods-icommands-4.1.11-centos6-x86_64.rpm

--- a/ansible/roles/irods-icommands/vars/Ubuntu.yml
+++ b/ansible/roles/irods-icommands/vars/Ubuntu.yml
@@ -6,4 +6,4 @@ ICOMMANDS_TAR: icommands_v331.ubuntu.x86_64.tar.bz2
 ICOMMANDS_DESTINATION: /opt
 BIN_PATH: /usr/local/bin
 
-ICOMMANDS_URL: http://s3-us-west-1.amazonaws.com/atmosphere-ansible-files/irods-icommands-4.1.9-cv-64bit-ubuntu-14.deb
+ICOMMANDS_URL: https://files.renci.org/pub/irods/releases/4.1.11/ubuntu14/irods-icommands-4.1.11-ubuntu14-x86_64.deb


### PR DESCRIPTION
… case there might be a package mismatch during kanki install

<!--
## Description

irods-command packages were removed from aws and now reference renci's official packages

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Add an entry in the changelog
- [ ] Documentation created/updated (include links)
- [ ] Reviewed and approved by at least one other contributor.
- [ ] New variables contributed to atmosphere/Clank
-->
