### PR TITLE
Update realvnc.yml

### DIFF
--- a/ansible/roles/atmo-vnc/tasks/realvnc.yml
+++ b/ansible/roles/atmo-vnc/tasks/realvnc.yml
@@ -91,23 +91,14 @@
     mode: 0755
     owner: '{{ ATMOUSERNAME }}'
 
-# NOTE template xstartup for centos 7 was in jetstream ONLY and should be evaluated
+# NOTE template xstartup for centos 7 and 8 - in jetstream ONLY and should be evaluated
 - name: template xstartup for vncserver for centos 7
   template:
     src: xstartup-cent7.j2
     dest: "/home/{{ ATMOUSERNAME }}/.vnc/xstartup"
     mode: 0755
     owner: "{{ ATMOUSERNAME }}"
-  when: (ansible_distribution == "CentOS") and (ansible_distribution_major_version == '7')
-
-# NOTE need this for CentOS 8 as well
-- name: template xstartup for vncserver for centos 8
-  template:
-    src: xstartup-cent7.j2
-    dest: "/home/{{ ATMOUSERNAME }}/.vnc/xstartup"
-    mode: 0755
-    owner: "{{ ATMOUSERNAME }}"
-  when: (ansible_distribution == "CentOS") and (ansible_distribution_major_version == '8')
+  when: (ansible_distribution == "CentOS") and (ansible_distribution_major_version|int >= 7)
 
 - name: ensure correct X server permissions
   file:

--- a/ansible/roles/atmo-vnc/tasks/realvnc.yml
+++ b/ansible/roles/atmo-vnc/tasks/realvnc.yml
@@ -100,6 +100,15 @@
     owner: "{{ ATMOUSERNAME }}"
   when: (ansible_distribution == "CentOS") and (ansible_distribution_major_version == '7')
 
+# NOTE need this for CentOS 8 as well
+- name: template xstartup for vncserver for centos 8
+  template:
+    src: xstartup-cent7.j2
+    dest: "/home/{{ ATMOUSERNAME }}/.vnc/xstartup"
+    mode: 0755
+    owner: "{{ ATMOUSERNAME }}"
+  when: (ansible_distribution == "CentOS") and (ansible_distribution_major_version == '8')
+
 - name: ensure correct X server permissions
   file:
     path: /etc/X11/xinit/xinitrc


### PR DESCRIPTION
<!--
## Description

Xvnc has no session manager in CentOS 8 -- same problem CentOS 7 originally had. This should fix it. The default xstartup looks for /usr/bin/*-session and then fails silently because there are multiple hits for that. 

-->
