### PR TITLE
Fix for ntp for CentOS8

### DIFF
--- a/ansible/playbooks/instance_deploy/10_setup_network_svcs.yml
+++ b/ansible/playbooks/instance_deploy/10_setup_network_svcs.yml
@@ -3,6 +3,6 @@
   hosts: all
   roles:
     - fix-centos6-networking
-    - atmo-ntp
+    - { role: atmo-ntp, when: ansible_distribution == "Ubuntu" or (ansible_distribution == "CentOS" and ansible_distribution_major_version|int < 8) }
     - { role: atmo-dhcp, when: SETUP_DHCP_CLIENT is defined and SETUP_DHCP_CLIENT == true }
     - atmo-fail2ban


### PR DESCRIPTION
No ntp on CentOS8, adding a check in playbook for `atmo-ntp` role
<!--
## Description

Please describe your pull request. If you're solving a problem, include a oneline problem and oneline solution statement. Otherwise, just begin with a single line summary.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Add an entry in the changelog
- [ ] Documentation created/updated (include links)
- [ ] Reviewed and approved by at least one other contributor.
- [ ] New variables contributed to atmosphere/Clank
-->
